### PR TITLE
Firefox fix for button overflowing event check in module

### DIFF
--- a/src/components/EventCheckIn/style.less
+++ b/src/components/EventCheckIn/style.less
@@ -30,7 +30,7 @@
       color: @blue-3;
       border: none;
       margin-right: 20px;
-      width:50%;
+      min-width:calc(100% - 140px);
     }
 
     .submit {

--- a/src/components/EventCheckIn/style.less
+++ b/src/components/EventCheckIn/style.less
@@ -30,6 +30,7 @@
       color: @blue-3;
       border: none;
       margin-right: 20px;
+      width:50%;
     }
 
     .submit {


### PR DESCRIPTION
This one actually fixes the issue for Firefox. It does what I think was implicitly being done on Chrome