### PR TITLE
Fix Event Points White Border

### DIFF
--- a/src/components/EventCard/index.jsx
+++ b/src/components/EventCard/index.jsx
@@ -16,15 +16,7 @@ const EventCard = props => {
         <p className="location">{props.location}</p>
       </div>
       <div className="circle">
-        <Progress
-          className="progress"
-          percent={100}
-          showInfo={false}
-          strokeColor="#22ACEA"
-          strokeWidth={12}
-          type="circle"
-          width={50}
-        />
+        <div className="inner"/>
         <h2 className="points">{props.points}</h2>
       </div>
       {props.auth.admin && (

--- a/src/components/EventCard/styles.less
+++ b/src/components/EventCard/styles.less
@@ -61,22 +61,26 @@
 
   .circle {
     align-items: center;
+    background-color: @blue-1;
+    border-radius: 50%;
     display: flex;
-    height: 40%;
+    height: 50px;
     justify-content: center;
     position: absolute;
-    right: -2.5%;
-    top: -5%;
-    width: 30%;
+    right: 5%;
+    top: 5%;
+    width: 50px;
+
+    .inner {
+      background-color: @white;
+      border-radius: 50%;
+      height: 37.5px;
+      width: 37.5px;
+    }
 
     .points {
       position: absolute;
       font-weight: 600;
-    }
-
-    .ant-progress {
-      background-color: @white;
-      border-radius: 50%;
     }
   }
 


### PR DESCRIPTION
The Ant Design progress ring doesn't align cleanly within its div, so I switched it to a static ring. It's now spaced an even 5% away from the top-right corner of the event card.

Resolves #202 