### PR TITLE
Maintain Proper Past Events Order

### DIFF
--- a/src/actions/eventsActions.js
+++ b/src/actions/eventsActions.js
@@ -117,6 +117,8 @@ export const fetchPastEvents = () => async dispatch => {
 
     // TODO: Mark the events as checked in if the user has attended them.
 
+    pastEvents.events.reverse();
+
     dispatch({
       type: FETCH_PAST_EVENTS,
       payload: pastEvents.events,

--- a/src/containers/PastEvents.jsx
+++ b/src/containers/PastEvents.jsx
@@ -14,7 +14,7 @@ const PastEventsContainer = props => {
 
   return (
     <EventsList>
-      {props.events.reverse().map(event => {
+      {props.events.map(event => {
         const startTime = formatDate(event.start);
         return (
           <EventCard


### PR DESCRIPTION
The PastEvents container was reversing the past events array in place on render. Rendering occurs twice on mobile browsers and this was causing the events array to flip twice and display in the wrong order. Switched to only reversing the array upon fetch so they maintain the same order for all cases with the most recent event on top.

Resolves #159 