### PR TITLE
Add Google Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "antd-demo",
-  "version": "0.1.0",
+  "name": "membership-portal-ui",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13623,6 +13623,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-ga": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
+      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
     },
     "react-is": {
       "version": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^16.13.1",
     "react-app-rewired": "^2.1.3",
     "react-dom": "^16.13.1",
+    "react-ga": "^2.7.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { Provider } from 'react-redux';
 import KonamiCode from 'konami-code';
 import BreadPage from './containers/egg/BreadPage/index';
 
+import ReactGA from 'react-ga';
+
 import configureStore, { history } from './store';
 
 import './styles/reset.less';
@@ -44,6 +46,8 @@ const App = () => {
     setEasterEggState('secret bread');
     history.push('/secret-bread');
   });
+  ReactGA.initialize('UA-165975388-1');
+  ReactGA.pageview('/');
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>

--- a/src/store.js
+++ b/src/store.js
@@ -3,9 +3,12 @@ import { applyMiddleware, compose, createStore } from 'redux';
 import { createBrowserHistory } from 'history';
 import { routerMiddleware } from 'connected-react-router';
 
+import ReactGA from 'react-ga';
+
 import createRootReducer from './reducers';
 
 export const history = createBrowserHistory();
+history.listen(location => ReactGA.pageview(location.pathname));
 
 export default function configureStore(preloadedState) {
   const store = createStore(


### PR DESCRIPTION
Closes #232.

Event calls are not necessary, since Heroku tracks membership portal events using dataclips.