### PR TITLE
Event Card: Add event time to Upcoming cards

### DIFF
--- a/src/containers/UpcomingEvents.jsx
+++ b/src/containers/UpcomingEvents.jsx
@@ -6,7 +6,7 @@ import EventCard from '../components/EventCard';
 import EventsList from '../components/EventsList';
 import background from '../assets/graphics/background.svg';
 import { fetchFutureEvents } from '../actions/eventsActions';
-import { formatDate } from '../utils';
+import { formatDate, formatTime } from '../utils';
 
 const UpcomingEventsContainer = (props) => {
   const { auth, events } = props;
@@ -18,13 +18,15 @@ const UpcomingEventsContainer = (props) => {
   return (
     <EventsList>
       {events.map((event) => {
-        const startTime = formatDate(event.start);
+        const startTime = formatTime(event.start);
+        const endTime = formatTime(event.end);
+        const date = `${formatDate(event.start)}, ${startTime} - ${endTime}`;
         return (
           <EventCard
             key={`upcoming-${event.uuid}`}
             uuid={event.uuid}
             cover={event.cover || background}
-            date={startTime}
+            date={date}
             description={event.description}
             location={event.location}
             points={event.pointValue}

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,9 +110,27 @@ export const formatDate = (time) => {
   ];
   const date = parsedDate.getDate();
   const monthIndex = parsedDate.getMonth();
-  const year = parsedDate.getFullYear();
 
-  return `${monthNames[monthIndex]} ${date} ${year}`;
+  return `${monthNames[monthIndex]} ${date}`;
+};
+/**
+ * Extracts the time from a UTC-formatted timestamp.
+ *
+ * Example: '1970-01-01T17:00:00.000Z' => '5:00 PM'
+ *
+ * @param {string} time The time in UTC string format.
+ * @return {string} The time of day.
+ */
+export const formatTime = (time) => {
+  const parsedTime = new Date(time);
+  const parsedHours = parsedTime.getHours();
+  const parsedMinutes = parsedTime.getMinutes();
+  const amOrPm = parsedHours >= 12 ? 'PM' : 'AM';
+  // edge case for midnight (0 in 24-hour format becomes 12 in 12-hour format)
+  const hours = parsedHours === 0 ? '12' : (parsedHours % 12).toString();
+  // pad single-minute times to double-digits (9 minutes => '09')
+  const minutes = parsedMinutes < 10 ? `0${parsedMinutes}` : parsedMinutes;
+  return `${hours}:${minutes} ${amOrPm}`;
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,24 +94,13 @@ export const getRank = (points) => {
 export const formatDate = (time) => {
   const parsedTime = Date.parse(time);
   const parsedDate = new Date(parsedTime);
-  const monthNames = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
-  const date = parsedDate.getDate();
-  const monthIndex = parsedDate.getMonth();
-
-  return `${monthNames[monthIndex]} ${date}`;
+  return parsedDate.toLocaleDateString(
+    {},
+    {
+      month: 'long',
+      day: 'numeric',
+    }
+  );
 };
 /**
  * Extracts the time from a UTC-formatted timestamp.
@@ -123,14 +112,14 @@ export const formatDate = (time) => {
  */
 export const formatTime = (time) => {
   const parsedTime = new Date(time);
-  const parsedHours = parsedTime.getHours();
-  const parsedMinutes = parsedTime.getMinutes();
-  const amOrPm = parsedHours >= 12 ? 'PM' : 'AM';
-  // edge case for midnight (0 in 24-hour format becomes 12 in 12-hour format)
-  const hours = parsedHours === 0 ? '12' : (parsedHours % 12).toString();
-  // pad single-minute times to double-digits (9 minutes => '09')
-  const minutes = parsedMinutes < 10 ? `0${parsedMinutes}` : parsedMinutes;
-  return `${hours}:${minutes} ${amOrPm}`;
+  return parsedTime.toLocaleTimeString(
+    {},
+    {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+    }
+  );
 };
 
 /**


### PR DESCRIPTION
Upcoming event cards display start and end time as well as the date.

Past events are omitted from this. Years are also removed from the event cards.