### PR TITLE
Fix Event Card Image Ratio

### DIFF
--- a/src/components/EventCard/styles.less
+++ b/src/components/EventCard/styles.less
@@ -31,7 +31,7 @@
   }
 
   img {
-    height: 60%;
+    height: 150px;
     margin: 0;
     object-fit: cover;
     width: 100%;


### PR DESCRIPTION
Right now, event card images have a ratio of 1.61. However, the event images have ratios of 1.77. I modified the sizing so that parts of the image don't get squeezed or cut off.

Resolved #293 