### PR TITLE
Add "credits" property to User state

### DIFF
--- a/src/reducers/UserReducer.ts
+++ b/src/reducers/UserReducer.ts
@@ -8,6 +8,7 @@ const initialState = {
     firstName: '',
     lastName: '',
     points: 0,
+    credits: 0,
     graduationYear: 0,
     profilePicture: defaultProfile,
   },


### PR DESCRIPTION
Resolves #320.

This PR adds the user's store credits to the user store and reducer. The API lists the store credits of a user under their model, in the property "credits".
This can be found under the [User database model file:](https://github.com/acmucsd/membership-portal/blob/dcb4e4d30e3296285e874a132e83e24a3233ed7a/src/db/models/user.js#L150-L153)
```js
module.exports = (Sequelize, db) => {
  const User = db.define('User', {
    id: {
      type: Sequelize.INTEGER,
      primaryKey: true,
      autoIncrement: true,
    },
  // --->8---    
  // spendable store credits, 1 exp point = 100 store credits
    credits: {
      type: Sequelize.INTEGER,
      defaultValue: 0,
    },  
 // --->8---
```

Testing the API route as well, we can also see that a seeded *test instance* account has 100 times its membership points as credits. You may try the following endpoints to verify this for yourself:
```http
POST https://acmucsd-portal-testing.herokuapp.com/api/v1/auth/login
Content-Type: application/json

{
  "email": "${username}",
  "password": "${password}"
}

GET https://acmucsd-portal-testing.herokuapp.com/api/v1/user
Authorization: Bearer ${JWT from above login}
```

Looking at the local store for the testing application on the `user-state-credit` branch once the page loads, we will notice the presence of the "credits" property in the state. This can be found by accessing the React store from the browser console. Here's a  screenshot of the revised User object in the store:

![Screencap of user store contents.](https://user-images.githubusercontent.com/11583824/88593336-11adcb00-d068-11ea-9a9d-67b3c8827bad.png)