### PR TITLE
Remove Authentication Alert for Base URL

### DIFF
--- a/src/actions/authActions.ts
+++ b/src/actions/authActions.ts
@@ -70,7 +70,7 @@ export const loginUser: ThunkActionCreator = (values, search) => async (dispatch
   }
 };
 
-export const verifyToken: ThunkActionCreator = (dispatch) => async (search) => {
+export const verifyToken: ThunkActionCreator = (dispatch) => async (search, pathname) => {
   return new Promise(async (resolve, reject) => {
     const token = Storage.get('token');
     if (token) {
@@ -129,7 +129,9 @@ export const verifyToken: ThunkActionCreator = (dispatch) => async (search) => {
         type: UNAUTH_USER,
       });
 
-      notify('Not Authenticated', 'Please sign in or register for an account before continuing.');
+      if (pathname.toString() !== '/') {
+        notify('Not Authenticated', 'Please sign in or register for an account before continuing.');
+      }
 
       // redirerct to /login
       dispatch(replace(`/login${search}`));

--- a/src/containers/requireAuth.tsx
+++ b/src/containers/requireAuth.tsx
@@ -6,12 +6,12 @@ import { replace } from 'connected-react-router';
 import { verifyToken } from '../actions/authActions';
 
 const withAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
-  const { authenticated, search } = props;
+  const { authenticated, pathname, search } = props;
 
   useEffect(() => {
     // check if authenticated, if not, then verify the token
     if (!authenticated) {
-      props.verify()(search);
+      props.verify()(search, pathname);
     }
   }, []);
 
@@ -25,6 +25,7 @@ const withAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   authenticated: state.auth.authenticated,
+  pathname: state.router.location.pathname,
   search: state.router.location.search,
 });
 


### PR DESCRIPTION
The notification "Please sign in or register for an account before continuing." will now only pop up if someone attempts to visit any location except for "/" without being signed in. This fixes the annoyance introduced by the check-in PR. I know the solution is a bit messy, but this is due to the action being nested weirdly. I'm going to look into cleaning up the actions as a future task to neaten things up.