### PR TITLE
Add Netlify configuration for Test Deploy Previews

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+REACT_APP_API_URL=https://acmucsd-portal-testing.herokuapp.com
+PORT=8080

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://acmucsd-membership-portal-api.herokuapp.com

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,14 @@
+[build]
+# Configure it so that deploy previews and `nightly` run on the testing instance, not
+# on the default instance
+[context.deploy-preview]
+  publish = "build/"
+  command = "CI=false npm run build:dev"
+[context.branch-deploy]
+  command = "CI=false npm run build:dev"
+[context.branch-deploy.environment]
+  NODE_ENV = "development"
+
 # The following redirect is intended for use with most SPAs that handle
 # routing internally.
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,8 @@
 [context.deploy-preview]
   publish = "build/"
   command = "CI=false npm run build:dev"
+[context.deploy-preview.environment]
+  NODE_ENV = "development"
 [context.branch-deploy]
   command = "CI=false npm run build:dev"
 [context.branch-deploy.environment]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7208,6 +7208,67 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
+    "dotenv-cli": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-4.0.0.tgz",
+      "integrity": "sha512-ByKEec+ashePEXthZaA1fif9XDtcaRnkN7eGdBDx3HHRjwZ/rA1go83Cbs4yRrx3JshsCf96FjAyIA2M672+CQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1",
+        "dotenv": "^8.1.0",
+        "dotenv-expand": "^5.1.0",
+        "minimist": "^1.1.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     "redux-thunk": "^2.3.0"
   },
   "scripts": {
-    "build": "react-app-rewired build",
+    "build:dev": "dotenv -e .env.development react-app-rewired build",
+    "build": "dotenv -e .env.production react-app-rewired build",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "eject": "react-scripts eject",
     "lint": "eslint \"**/*.{ts,tsx}\" && npx stylelint \"**/*.less\"",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix && npx stylelint \"**/*.less\" --fix",
-    "start": "cross-env PORT=8080 react-app-rewired start",
+    "start": "dotenv -e .env.development react-app-rewired start",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -73,6 +74,7 @@
     "babel-jest": "^24.8.0",
     "coveralls": "^3.0.6",
     "cross-env": "^7.0.2",
+    "dotenv-cli": "^4.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,4 @@
-let apiurl = 'https://acmucsd-membership-portal-api.herokuapp.com';
-if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-  apiurl = 'https://acmucsd-portal-testing.herokuapp.com';
-}
+const apiurl = process.env.REACT_APP_API_URL;
 
 export default {
   API_URL: apiurl,


### PR DESCRIPTION
This PR adds the configuration necessary for Netlify to
deploy development builds for previews and branches such as
`nightly`, branches off of `nightly` and deploy previews for
PR's.

Note that this PR uses `dotenv` to deploy environment variables
instead of `cross-env`, and I haven't tested `dotenv` on Windows.
If this ends up not working on Windows, I can change everything back
to `cross-env`.