### PR TITLE
Add lazy-loading to Event Card images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14893,6 +14893,15 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-lazy-load-image-component": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-lazy-load-image-component/-/react-lazy-load-image-component-1.5.0.tgz",
+      "integrity": "sha512-dAvuueTq0FNjswHEII8tcd0FRRHZgPoIdVhE1fcAfCdqY7LZ37IHd0xWb2c6rCl+dsSm9Z4AloEffM8JYPxTlA==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1"
+      }
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^16.13.1",
     "react-ga": "^2.7.0",
     "react-iframe": "^1.8.0",
+    "react-lazy-load-image-component": "^1.5.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -1,6 +1,7 @@
 import { Icon } from 'antd';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import { LazyLoadImage } from 'react-lazy-load-image-component';
 
 import { isURL, getAbsoluteURL } from '../../utils';
 
@@ -25,7 +26,7 @@ const EventCard: React.FC<EventCardProps> = (props) => {
   return (
     <div className="event-card">
       <div className="front-facing">
-        <img className="image" src={cover} alt={title} />
+        <LazyLoadImage className="image" src={cover} alt={title} />
         <div className="info">
           <h2 className="title">{title}</h2>
           <p className="date">{date}</p>


### PR DESCRIPTION
All images on Event Cards are now lazy-loaded using external package.

This change bumps the average load time of home page from 7.29 seconds down to
1.94 seconds, which is a massive difference. Here are screenshots from the
Firefox Developer Tools showing the difference in loading times before the
lazy-load change:

![Load time before lazy-loading.](https://i.imgur.com/52UByji.png)

And after it:

![Load time after lazy loading](https://i.imgur.com/52UByji.png)

While the images still require loading when rendered, the initial loading shock
is not as large. However, important to note that the actual image sizes should
be reduced down from 1080p, as that resolution is wasteful for the size of the
images used.

The resolution change is either mandated by the backend, or can be done with an
external script uploading old event cards to an S3 bucket at a downscaled
resolution and updating existing events using it.