### PR TITLE
Add additional ranks

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,7 @@ export const getRank = (points: number): string => {
     'Sometime(TM)',
     'We Ran Out Of Ranks',
   ];
-  const index = Math.min(ranks.length, Math.floor(points / 100));
+  const index = Math.min(ranks.length - 1, Math.floor(points / 100));
   return ranks[index];
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,10 @@ export const getRank = (points: number): string => {
     'Binary Baguette',
     'Blessed Boba',
     'Super Snu',
+    'Soon(TM)',
+    'Later(TM)',
+    'Sometime(TM)',
+    'We Ran Out Of Ranks',
   ];
   const index = Math.min(ranks.length, Math.floor(points / 100));
   return ranks[index];


### PR DESCRIPTION
This PR adds some additional placeholders for ranks. They are more or less designed as cheeky placeholders until we come up with some better rank names.

We additionally fix the issue with overflowing the rank by editing the formula, since we wouldn't account
for 0-indexing.