### PR TITLE
Trim whitespace for "Location" in Event forms

### DIFF
--- a/src/admin/containers/CreateEventForm.tsx
+++ b/src/admin/containers/CreateEventForm.tsx
@@ -81,7 +81,7 @@ const FormikCreateEventForm = withFormik({
 
     const event = {
       title: values.title,
-      location: values.location,
+      location: values.location.trim(),
       pointValue: values.pointValue,
       start: new Date(`${startDate.format('LL')} ${startTime.format('LT')}`).toISOString(),
       end: new Date(`${endDate.format('LL')} ${endTime.format('LT')}`).toISOString(),

--- a/src/admin/containers/EditEventForm.tsx
+++ b/src/admin/containers/EditEventForm.tsx
@@ -83,7 +83,7 @@ const FormikEditEventForm = withFormik({
     const event = {
       uuid: values.uuid,
       title: values.title,
-      location: values.location,
+      location: values.location.trim(),
       pointValue: values.pointValue,
       start: new Date(`${startDate.format('LL')} ${startTime.format('LT')}`).toISOString(),
       end: new Date(`${endDate.format('LL')} ${endTime.format('LT')}`).toISOString(),


### PR DESCRIPTION
URL's are not rendered in the Event card due to the internal "Location"
value occasionally containing trailing whitespace and tripping the regex
for URL's. Trim whitespace on "Location" value before submitting a
"Create Event" or "Edit Event" form.