### PR TITLE
Add Yup Schema for Event Creation and Editing Flow

### DIFF
--- a/src/admin/components/CreateEventForm/index.tsx
+++ b/src/admin/components/CreateEventForm/index.tsx
@@ -117,7 +117,7 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
                 minuteStep={15}
                 value={values.endTime}
                 onChange={(time) => setFieldValue('endTime', time)}
-              />{' '}
+              />
               <p className="form-error">{errors.endTime ? errors.endTime : null}</p>
             </Form.Item>
           </div>

--- a/src/admin/components/CreateEventForm/index.tsx
+++ b/src/admin/components/CreateEventForm/index.tsx
@@ -28,12 +28,25 @@ interface CreateEventFormProps {
     attendanceCode: string;
     description: string;
   };
+  errors: {
+    title: string | null;
+    committee: string | null;
+    location: string | null;
+    pointValue: string | null;
+    startDate: string | null;
+    startTime: string | null;
+    endDate: string | null;
+    endTime: string | null;
+    cover: string | null;
+    attendanceCode: string | null;
+    description: string | null;
+  };
   copyLink: Function;
 }
 
 /* Future Note: Add a fun generate attendance code function :) based on title */
 const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
-  const { handleBlur, handleChange, handleSubmit, setFieldTouched, setFieldValue, values, copyLink } = props;
+  const { handleBlur, handleChange, handleSubmit, setFieldTouched, setFieldValue, values, errors, copyLink } = props;
 
   return (
     <div className="create-event-form">
@@ -43,6 +56,7 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
           <Form.Item label="Event Title">
             <Input name="title" className="input-box" value={values.title} onChange={handleChange} onBlur={handleBlur} />
           </Form.Item>
+          <p className="form-error">{errors.title ? errors.title : null}</p>
           <Form.Item className="committee-wrapper" label="Community">
             <Select
               showSearch
@@ -62,17 +76,21 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
               ))}
             </Select>
           </Form.Item>
+          <p className="form-error">{errors.committee ? errors.committee : null}</p>
           <div className="horizontal-input">
             <Form.Item className="location-wrapper" label="Location">
               <Input name="location" className="location" value={values.location} onChange={handleChange} onBlur={handleBlur} />
+              <p className="form-error">{errors.location ? errors.location : null}</p>
             </Form.Item>
             <Form.Item className="points-wrapper" label="Points">
               <Input name="pointValue" className="points" value={values.pointValue} onChange={handleChange} onBlur={handleBlur} />
+              <p className="form-error">{errors.pointValue ? errors.pointValue : null}</p>
             </Form.Item>
           </div>
           <div className="horizontal-input">
             <Form.Item className="date-wrapper" label="Start Date">
               <DatePicker className="date" value={values.startDate} onChange={(date) => setFieldValue('startDate', date)} />
+              <p className="form-error">{errors.startDate ? errors.startDate : null}</p>
             </Form.Item>
             <Form.Item className="time-wrapper" label="Start Time">
               <TimePicker
@@ -83,11 +101,13 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
                 value={values.startTime}
                 onChange={(time) => setFieldValue('startTime', time)}
               />
+              <p className="form-error">{errors.startTime ? errors.startTime : null}</p>
             </Form.Item>
           </div>
           <div className="horizontal-input">
             <Form.Item className="date-wrapper" label="End Date">
               <DatePicker className="date" value={values.endDate} onChange={(date) => setFieldValue('endDate', date)} />
+              <p className="form-error">{errors.endDate ? errors.endDate : null}</p>
             </Form.Item>
             <Form.Item className="time-wrapper" label="End Time">
               <TimePicker
@@ -97,7 +117,8 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
                 minuteStep={15}
                 value={values.endTime}
                 onChange={(time) => setFieldValue('endTime', time)}
-              />
+              />{' '}
+              <p className="form-error">{errors.endTime ? errors.endTime : null}</p>
             </Form.Item>
           </div>
           <Form.Item className="cover-wrapper" label="Cover Link">
@@ -113,11 +134,14 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
               <Button>Click to upload</Button>
             </Upload>
           </Form.Item>
+          <p className="form-error">{errors.cover ? errors.cover : null}</p>
           <Form.Item label="Attendance Code">
             <Input name="attendanceCode" className="input-box" value={values.attendanceCode} onChange={handleChange} onBlur={handleBlur} />
+            <p className="form-error">{errors.attendanceCode ? errors.attendanceCode : null}</p>
           </Form.Item>
           <Form.Item label="Description">
             <TextArea name="description" className="area-box" value={values.description} onChange={handleChange} onBlur={handleBlur} />
+            <p className="form-error">{errors.description ? errors.description : null}</p>
           </Form.Item>
           <Button type="primary" htmlType="submit" className="save-button">
             Add Event

--- a/src/admin/components/CreateEventForm/style.less
+++ b/src/admin/components/CreateEventForm/style.less
@@ -141,6 +141,12 @@
     }
   }
 
+  .form-error {
+    color: #f66;
+    height: 20px;
+    white-space: nowrap;
+  }
+
   .ant-form-item-label {
     line-height: 30px;
   }

--- a/src/admin/components/EditEventForm/index.tsx
+++ b/src/admin/components/EditEventForm/index.tsx
@@ -27,10 +27,24 @@ interface EditEventFormProps {
   handleSubmit: FormEventHandler;
   values: { [key: string]: any };
   copyLink: Function;
+  errors: {
+    uuid: string | null;
+    title: string | null;
+    location: string | null;
+    pointValue: string | null;
+    startDate: string | null;
+    startTime: string | null;
+    endDate: string | null;
+    endTime: string | null;
+    cover: string | null;
+    description: string | null;
+    attendanceCode: string | null;
+    committee: string | null;
+  };
 }
 
 const EditEventForm: React.FC<EditEventFormProps> = (props) => {
-  const { event, setFieldValue, setFieldTouched, handleBlur, handleChange, handleSubmit, values, copyLink } = props;
+  const { event, setFieldValue, setFieldTouched, handleBlur, handleChange, handleSubmit, values, errors, copyLink } = props;
 
   const params: { [key: string]: any } = useParams();
   const history = useHistory();
@@ -80,6 +94,7 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
           <Form.Item label="Event Title">
             <Input name="title" className="input-box" value={values.title} onChange={handleChange} onBlur={handleBlur} />
           </Form.Item>
+          <p className="form-error">{errors.title ? errors.title : null}</p>
           <Form.Item className="committee-wrapper" label="Community">
             <Select
               showSearch
@@ -99,17 +114,21 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
               ))}
             </Select>
           </Form.Item>
+          <p className="form-error">{errors.committee ? errors.committee : null}</p>
           <div className="horizontal-input">
             <Form.Item className="location-wrapper" label="Location">
               <Input name="location" className="location" value={values.location} onChange={handleChange} onBlur={handleBlur} />
+              <p className="form-error">{errors.location ? errors.location : null}</p>
             </Form.Item>
             <Form.Item className="points-wrapper" label="Points">
               <Input name="pointValue" className="points" value={values.pointValue} onChange={handleChange} onBlur={handleBlur} />
+              <p className="form-error">{errors.pointValue ? errors.pointValue : null}</p>
             </Form.Item>
           </div>
           <div className="horizontal-input">
             <Form.Item className="date-wrapper" label="Start Date">
               <DatePicker className="date" value={values.startDate} onChange={(date) => setFieldValue('startDate', date)} />
+              <p className="form-error">{errors.startDate ? errors.startDate : null}</p>
             </Form.Item>
             <Form.Item className="time-wrapper" label="Start Time">
               <TimePicker
@@ -120,11 +139,13 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
                 value={values.startTime}
                 onChange={(time) => setFieldValue('startTime', time)}
               />
+              <p className="form-error">{errors.startTime ? errors.startTime : null}</p>
             </Form.Item>
           </div>
           <div className="horizontal-input">
             <Form.Item className="date-wrapper" label="End Date">
               <DatePicker className="date" value={values.endDate} onChange={(date) => setFieldValue('endDate', date)} />
+              <p className="form-error">{errors.endDate ? errors.endDate : null}</p>
             </Form.Item>
             <Form.Item className="time-wrapper" label="End Time">
               <TimePicker
@@ -135,6 +156,7 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
                 value={values.endTime}
                 onChange={(time) => setFieldValue('endTime', time)}
               />
+              <p className="form-error">{errors.endTime ? errors.endTime : null}</p>
             </Form.Item>
           </div>
           <Form.Item className="cover-wrapper" label="Cover Link">
@@ -149,12 +171,15 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
             >
               <Button>Click to upload</Button>
             </Upload>
+            <p className="form-error">{errors.cover ? errors.cover : null}</p>
           </Form.Item>
           <Form.Item label="Attendance Code">
             <Input name="attendanceCode" className="input-box" value={values.attendanceCode} onChange={handleChange} onBlur={handleBlur} />
+            <p className="form-error">{errors.attendanceCode ? errors.attendanceCode : null}</p>
           </Form.Item>
           <Form.Item label="Description">
             <TextArea name="description" className="area-box" value={values.description} onChange={handleChange} onBlur={handleBlur} />
+            <p className="form-error">{errors.description ? errors.description : null}</p>
           </Form.Item>
           <Button type="primary" htmlType="submit" className="save-button">
             Submit Edits

--- a/src/admin/components/EditEventForm/style.less
+++ b/src/admin/components/EditEventForm/style.less
@@ -151,6 +151,12 @@
     }
   }
 
+  .form-error {
+    color: #f66;
+    height: 10px;
+    white-space: nowrap;
+  }
+
   .ant-form-item-label {
     line-height: 30px;
   }

--- a/src/admin/containers/CreateEventForm.tsx
+++ b/src/admin/containers/CreateEventForm.tsx
@@ -9,7 +9,7 @@ import { postEvent, copyLink } from '../adminActions';
 const CreateEventSchema = Yup.object().shape({
   title: Yup.string().required('Required'),
   location: Yup.string().required('Required'),
-  pointValue: Yup.number().required('Required').positive('Must be positive').moreThan(0, 'Must be greater than 0').integer('Must be an integer'),
+  pointValue: Yup.number().required('Required').moreThan(0, 'Must be greater than 0').integer('Must be an integer'),
   startDate: Yup.date().typeError('Not a date').required('Required'),
   startTime: Yup.date().typeError('Not a time').required('Required'),
   endDate: Yup.date().typeError('Not a date').required('Required'),

--- a/src/admin/containers/CreateEventForm.tsx
+++ b/src/admin/containers/CreateEventForm.tsx
@@ -1,9 +1,24 @@
 import { connect } from 'react-redux';
 import { withFormik } from 'formik';
+import * as Yup from 'yup';
 
+import Moment from 'moment';
 import CreateEventForm from '../components/CreateEventForm';
 import { postEvent, copyLink } from '../adminActions';
-import { notify } from '../../utils';
+
+const CreateEventSchema = Yup.object().shape({
+  title: Yup.string().required('Required'),
+  location: Yup.string().required('Required'),
+  pointValue: Yup.number().required('Required').positive('Must be positive').moreThan(0, 'Must be greater than 0').integer('Must be an integer'),
+  startDate: Yup.date().typeError('Not a date').required('Required'),
+  startTime: Yup.date().typeError('Not a time').required('Required'),
+  endDate: Yup.date().typeError('Not a date').required('Required'),
+  endTime: Yup.date().typeError('Not a time').required('Required'),
+  cover: Yup.string().required('Required'),
+  description: Yup.string().required('Required'),
+  attendanceCode: Yup.string().required('Required'),
+  committee: Yup.string().required('Required'),
+});
 
 const FormikCreateEventForm = withFormik({
   mapPropsToValues() {
@@ -21,70 +36,18 @@ const FormikCreateEventForm = withFormik({
       committee: '',
     };
   },
+  validationSchema: CreateEventSchema,
+  validateOnChange: false,
+  validateOnBlur: false,
   handleSubmit(values, { resetForm, props }: { [key: string]: any }) {
     const { startDate, startTime, endDate, endTime } = values;
-
-    if (values.title === '') {
-      notify('Event Creation Error', 'Title is required.');
-      return;
-    }
-
-    if (values.location === '') {
-      notify('Event Creation Error', 'Location is required.');
-      return;
-    }
-
-    if (values.pointValue === 0) {
-      notify('Event Creation Error', 'Points is required.');
-      return;
-    }
-
-    if (!startDate) {
-      notify('Event Creation Error', 'Start Date is required.');
-      return;
-    }
-
-    if (!startTime) {
-      notify('Event Creation Error', 'Start Time is required.');
-      return;
-    }
-
-    if (!endDate) {
-      notify('Event Creation Error', 'End Date is required.');
-      return;
-    }
-
-    if (!endTime) {
-      notify('Event Creation Error', 'End Time is required.');
-      return;
-    }
-
-    if (values.cover === '') {
-      notify('Event Creation Error', 'Cover is required.');
-      return;
-    }
-
-    if (values.description === '') {
-      notify('Event Creation Error', 'Description is required.');
-      return;
-    }
-
-    if (values.attendanceCode === '') {
-      notify('Event Creation Error', 'Attendance Code is required.');
-      return;
-    }
-
-    if (values.committee === '') {
-      notify('Event Creation Error', 'Community is required.');
-      return;
-    }
 
     const event = {
       title: values.title,
       location: values.location.trim(),
       pointValue: values.pointValue,
-      start: new Date(`${startDate.format('LL')} ${startTime.format('LT')}`).toISOString(),
-      end: new Date(`${endDate.format('LL')} ${endTime.format('LT')}`).toISOString(),
+      start: new Date(`${Moment(startDate).format(`LL`)} ${Moment(startTime).format(`LT`)}`).toISOString(),
+      end: new Date(`${Moment(endDate).format(`LL`)} ${Moment(endTime).format(`LT`)}`).toISOString(),
       cover: values.cover,
       attendanceCode: values.attendanceCode,
       description: values.description,

--- a/src/admin/containers/EditEventForm.tsx
+++ b/src/admin/containers/EditEventForm.tsx
@@ -9,7 +9,7 @@ import { editEvent, deleteEvent, copyLink } from '../adminActions';
 const EditEventSchema = Yup.object().shape({
   title: Yup.string().required('Required'),
   location: Yup.string().required('Required'),
-  pointValue: Yup.number().required('Required').positive('Must be positive').moreThan(0, 'Must be greater than 0').integer('Must be an integer'),
+  pointValue: Yup.number().required('Required').moreThan(0, 'Must be greater than 0').integer('Must be an integer'),
   startDate: Yup.date().typeError('Not a date').required('Required'),
   startTime: Yup.date().typeError('Not a time').required('Required'),
   endDate: Yup.date().typeError('Not a date').required('Required'),

--- a/src/admin/containers/EditEventForm.tsx
+++ b/src/admin/containers/EditEventForm.tsx
@@ -1,9 +1,24 @@
 import { connect } from 'react-redux';
 import { withFormik } from 'formik';
+import * as Yup from 'yup';
+import Moment from 'moment';
 
-import EditEventform from '../components/EditEventForm';
+import EditEventForm from '../components/EditEventForm';
 import { editEvent, deleteEvent, copyLink } from '../adminActions';
-import { notify } from '../../utils';
+
+const EditEventSchema = Yup.object().shape({
+  title: Yup.string().required('Required'),
+  location: Yup.string().required('Required'),
+  pointValue: Yup.number().required('Required').positive('Must be positive').moreThan(0, 'Must be greater than 0').integer('Must be an integer'),
+  startDate: Yup.date().typeError('Not a date').required('Required'),
+  startTime: Yup.date().typeError('Not a time').required('Required'),
+  endDate: Yup.date().typeError('Not a date').required('Required'),
+  endTime: Yup.date().typeError('Not a time').required('Required'),
+  cover: Yup.string(),
+  description: Yup.string().required('Required'),
+  attendanceCode: Yup.string().required('Required'),
+  committee: Yup.string().required('Required'),
+});
 
 const FormikEditEventForm = withFormik({
   mapPropsToValues() {
@@ -22,71 +37,19 @@ const FormikEditEventForm = withFormik({
       committee: '',
     };
   },
+  validationSchema: EditEventSchema,
+  validateOnChange: false,
+  validateOnBlur: false,
   handleSubmit(values, { props }: { [key: string]: any }) {
     const { startDate, startTime, endDate, endTime } = values;
-
-    if (values.title === '') {
-      notify('Event Edit Error', 'Title is required.');
-      return;
-    }
-
-    if (values.location === '') {
-      notify('Event Edit Error', 'Location is required.');
-      return;
-    }
-
-    if (values.pointValue === 0) {
-      notify('Event Edit Error', 'Points is required.');
-      return;
-    }
-
-    if (!startDate) {
-      notify('Event Edit Error', 'Start Date is required.');
-      return;
-    }
-
-    if (!startTime) {
-      notify('Event Edit Error', 'Start Time is required.');
-      return;
-    }
-
-    if (!endDate) {
-      notify('Event Edit Error', 'End Date is required.');
-      return;
-    }
-
-    if (!endTime) {
-      notify('Event Edit Error', 'End Time is required.');
-      return;
-    }
-
-    if (values.cover === '') {
-      notify('Event Edit Error', 'Cover is required.');
-      return;
-    }
-
-    if (values.description === '') {
-      notify('Event Edit Error', 'Description is required.');
-      return;
-    }
-
-    if (values.attendanceCode === '') {
-      notify('Event Edit Error', 'Attendance Code is required.');
-      return;
-    }
-
-    if (values.committee === '') {
-      notify('Event Edit Error', 'Community is required.');
-      return;
-    }
 
     const event = {
       uuid: values.uuid,
       title: values.title,
       location: values.location.trim(),
       pointValue: values.pointValue,
-      start: new Date(`${startDate.format('LL')} ${startTime.format('LT')}`).toISOString(),
-      end: new Date(`${endDate.format('LL')} ${endTime.format('LT')}`).toISOString(),
+      start: new Date(`${Moment(startDate).format(`LL`)} ${Moment(startTime).format(`LT`)}`).toISOString(),
+      end: new Date(`${Moment(endDate).format(`LL`)} ${Moment(endTime).format(`LT`)}`).toISOString(),
       cover: values.cover,
       attendanceCode: values.attendanceCode,
       description: values.description,
@@ -98,6 +61,6 @@ const FormikEditEventForm = withFormik({
       .then(() => {})
       .catch(() => {});
   },
-})(EditEventform as React.FC);
+})(EditEventForm as React.FC);
 
 export default connect(null, { editEvent, deleteEvent, copyLink })(FormikEditEventForm);


### PR DESCRIPTION
Resolves #421.

Forms for creating and editing events use simple `if` statements
as opposed to a Yup schema, which is a standard. Refactor form errors
to use Yup schema for CreateEventForm and EditEventForm.