### PR TITLE
Add Empty Bio Handling

### DIFF
--- a/src/profile/containers/ProfileUpdate.tsx
+++ b/src/profile/containers/ProfileUpdate.tsx
@@ -15,10 +15,8 @@ const FormikProfileUpdate = withFormik({
     };
   },
   handleSubmit(values, { props }: { [key: string]: any }) {
-    props
-      .updateProfile(values)
-      .then(() => {})
-      .catch(() => {});
+    // Run updateProfile action. Bio must be null if blank, because empty strings aren't accepted by the backend.
+    props.updateProfile({ ...values, bio: values.bio === '' ? null : values.bio });
   },
 })(ProfileUpdate as React.FC);
 


### PR DESCRIPTION
Call the `updateProfile` action correctly in regards to the user bio. The bio must be null if it is empty, since empty strings aren't accepted by the backend.

Resolves #436.