### PR TITLE
fix: improved bio whitespace handling

### DIFF
--- a/src/profile/components/ProfilePage/index.tsx
+++ b/src/profile/components/ProfilePage/index.tsx
@@ -56,14 +56,12 @@ const ProfilePage: React.FC<ProfilePageProps> = (props) => {
           </div>
           <div className="meta-data bio">
             <h2>Bio</h2>
-
-            {(!/^[\r\n\s]*$/.test(stateUser.profile.bio as string)
-              && (stateUser.profile.bio as string)?.split('\n').map((item, key) => (
-                item
-                  ? <p key={key}>{item}</p>
-                  : <br />
-              ))) || <p>This user hasn't added a bio yet!</p>
-            }
+            <p>
+              {!/^\s*$/.test(stateUser.profile.bio as string)
+                ? stateUser.profile.bio
+                : "This user hasn't added a bio yet!"
+              }
+            </p>
           </div>
           {!params.uuid && (
             <Link to="/editProfile">

--- a/src/profile/components/ProfilePage/index.tsx
+++ b/src/profile/components/ProfilePage/index.tsx
@@ -57,9 +57,13 @@ const ProfilePage: React.FC<ProfilePageProps> = (props) => {
           <div className="meta-data bio">
             <h2>Bio</h2>
 
-            {((stateUser.profile.bio as string) || "This user hasn't added a bio yet!").split('\n').map((item, key) => {
-              return <p key={key}>{item}</p>;
-            })}
+            {(!/^[\r\n\s]*$/.test(stateUser.profile.bio as string)
+              && (stateUser.profile.bio as string)?.split('\n').map((item, key) => (
+                item
+                  ? <p key={key}>{item}</p>
+                  : <br />
+              ))) || <p>This user hasn't added a bio yet!</p>
+            }
           </div>
           {!params.uuid && (
             <Link to="/editProfile">

--- a/src/profile/components/ProfilePage/style.less
+++ b/src/profile/components/ProfilePage/style.less
@@ -52,5 +52,6 @@
 
   .bio > p {
     overflow-wrap: anywhere;
+    white-space: pre-wrap;
   }
 }


### PR DESCRIPTION
- empty lines properly form line breaks

```
a

b
```
![image](https://user-images.githubusercontent.com/38791932/116167675-8a07f200-a6b5-11eb-8839-2489f3a25e86.png)

- bios consisting of all line break/whitespace properly recognized as empty

```
     

  
    
```
![image](https://user-images.githubusercontent.com/38791932/116167740-ba4f9080-a6b5-11eb-94d3-f2c69794334a.png)


