### PR TITLE
Add GitHub Actions to manage PR labels

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,14 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - steets250
+  - StormFireFox1
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0

--- a/.github/workflows/assign_reviewers_to_new_pr.yml
+++ b/.github/workflows/assign_reviewers_to_new_pr.yml
@@ -11,3 +11,4 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: "PR: Needs Review"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assign_reviewers_to_new_pr.yml
+++ b/.github/workflows/assign_reviewers_to_new_pr.yml
@@ -1,0 +1,13 @@
+name: 'Auto-Assign Reviewers and Label to New PR'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews-and-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: "PR: Needs Review"

--- a/.github/workflows/label_ready_pr_to_merge.yml
+++ b/.github/workflows/label_ready_pr_to_merge.yml
@@ -1,0 +1,15 @@
+name: 'Add Label to Fully-Reviewed PR'
+on: pull_request_review
+jobs:
+  labelWhenApproved:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add approval label
+        uses: pullreminders/label-when-approved-action@master
+        env:
+          APPROVALS: 2
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ADD_LABEL: "PR: Good to Merge"
+          REMOVE_LABEL: |
+            "PR: Needs Review"
+            "PR: Reviewed w/ Comments"


### PR DESCRIPTION
Workflow for Dev Team involved adding or removing "PR" labels depending on stage
in approval process. Automate this workflow using GitHub Actions, modifying labels
whenever PR is fully approved.

Also add action to automatically assign at least two reviewers to PR.