### PR TITLE
Event cover resizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "antd": "3.24.3",
+    "antd-img-crop": "^3.14.1",
     "babel-plugin-import": "^1.12.0",
     "connected-react-router": "^6.5.2",
     "copy-to-clipboard": "^3.3.1",

--- a/src/admin/components/CreateEventForm/index.tsx
+++ b/src/admin/components/CreateEventForm/index.tsx
@@ -1,5 +1,8 @@
 import React, { ChangeEventHandler, FocusEventHandler, FormEventHandler } from 'react';
 import { Form, Input, Button, Select, DatePicker, TimePicker, Upload } from 'antd';
+import ImgCrop from 'antd-img-crop';
+import 'antd/es/modal/style';
+import 'antd/es/slider/style';
 import * as moment from 'moment';
 import { useHistory } from 'react-router-dom';
 
@@ -124,17 +127,19 @@ const CreateEventForm: React.FC<CreateEventFormProps> = (props) => {
             </Form.Item>
           </div>
           <Form.Item className="cover-wrapper" label="Cover Link">
-            <Upload
-              name="cover"
-              className="cover"
-              accept="image/*"
-              listType="picture"
-              customRequest={(options) => {
-                setFieldValue('cover', options.file);
-              }}
-            >
-              <Button>Click to upload</Button>
-            </Upload>
+            <ImgCrop aspect={16 / 9}>
+              <Upload
+                name="cover"
+                className="cover"
+                accept="image/*"
+                listType="picture"
+                customRequest={(options) => {
+                  setFieldValue('cover', options.file);
+                }}
+              >
+                <Button>Click to upload</Button>
+              </Upload>
+            </ImgCrop>
           </Form.Item>
           <p className="form-error">{errors.cover ? errors.cover : null}</p>
           <Form.Item label="Attendance Code">

--- a/src/admin/components/EditEventForm/index.tsx
+++ b/src/admin/components/EditEventForm/index.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, FocusEventHandler, ChangeEventHandler, FormEventHandler } from 'react';
 import { Form, Input, Button, Select, DatePicker, TimePicker, Upload } from 'antd';
+import ImgCrop from 'antd-img-crop';
+import 'antd/es/modal/style';
+import 'antd/es/slider/style';
 import { useParams, useHistory } from 'react-router-dom';
 import * as moment from 'moment';
 import { notify } from '../../../utils';
@@ -160,17 +163,19 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
             </Form.Item>
           </div>
           <Form.Item className="cover-wrapper" label="Cover Link">
-            <Upload
-              name="cover"
-              className="cover"
-              accept="image/*"
-              listType="picture"
-              customRequest={(options) => {
-                setFieldValue('cover', options.file);
-              }}
-            >
-              <Button>Click to upload</Button>
-            </Upload>
+            <ImgCrop aspect={16 / 9}>
+              <Upload
+                name="cover"
+                className="cover"
+                accept="image/*"
+                listType="picture"
+                customRequest={(options) => {
+                  setFieldValue('cover', options.file);
+                }}
+              >
+                <Button>Click to upload</Button>
+              </Upload>
+            </ImgCrop>
             <p className="form-error">{errors.cover ? errors.cover : null}</p>
           </Form.Item>
           <Form.Item label="Attendance Code">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,6 +1179,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.4":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.6.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -2239,6 +2246,14 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+antd-img-crop@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/antd-img-crop/-/antd-img-crop-3.14.1.tgz#4e824425defea29fb1913b2460e5c2382a247c68"
+  integrity sha512-m9znzbghh+e9K4//CaNGYfuSM/aUGsX+sByCc/Qo8jDmQSWpg05onNvbOHFVtxht1DfyGypgyEQ11JDikS7ERg==
+  dependencies:
+    "@babel/runtime" "^7.13.4"
+    react-easy-crop "^3.3.1"
 
 antd@3.24.3:
   version "3.24.3"
@@ -8389,6 +8404,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+normalize-wheel@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-wheel/-/normalize-wheel-1.0.1.tgz#aec886affdb045070d856447df62ecf86146ec45"
+  integrity sha1-rsiGr/2wRQcNhWRH32Ls+GFG7EU=
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -10501,6 +10521,14 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-easy-crop@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/react-easy-crop/-/react-easy-crop-3.3.3.tgz#665940d95c3128b0f6b52c5cd8a5d1a5cdba5382"
+  integrity sha512-CumnUN7GrGaMBK2k3nOG7By8q6IG/JfXO9ytXZHndhx6HFdlUxz1j11vm7hXBmTWDaQ9XtPSZaqSPI9ye5CiGw==
+  dependencies:
+    normalize-wheel "^1.0.1"
+    tslib "2.0.1"
+
 react-error-overlay@^6.0.3:
   version "6.0.8"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.8.tgz#474ed11d04fc6bda3af643447d85e9127ed6b5de"
@@ -12473,6 +12501,11 @@ tsconfig-paths@^3.9.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"


### PR DESCRIPTION
resolves #425 

Uses `antd-img-crop` to provide 16:9 cropping modal for admin event cover uploads.