### PR TITLE
Fix Delete Event Logic

### DIFF
--- a/src/admin/adminActions.ts
+++ b/src/admin/adminActions.ts
@@ -72,25 +72,20 @@ export const deleteEvent: ThunkActionCreator = (uuid) => async (dispatch) => {
   return new Promise(async (resolve, reject) => {
     try {
       const url = `${Config.API_URL}${Config.routes.events.event}/${uuid}`;
-      const data = await fetchService(url, 'DELETE', 'json', {
+      await fetchService(url, 'DELETE', 'json', {
         requiresAuthorization: true,
         onFailCallback: () => dispatch(logoutUser()),
       });
 
-      if (data.numDeleted === 1) {
-        dispatch({
-          type: EVENT_DELETE,
-          uuid,
-        });
-        notify('Success!', 'You successfully deleted the event!');
-        resolve('Deleted');
-      } else {
-        notify('Unable to delete event!', "Couldn't find the event in the database");
-        reject(new Error('Delete failed'));
-      }
+      dispatch({
+        type: EVENT_DELETE,
+        uuid,
+      });
+      notify('Success!', 'You successfully deleted the event!');
+      resolve();
     } catch (error) {
       notify('Unable to delete event!', error.message);
-      reject(error);
+      reject();
     }
   });
 };

--- a/src/admin/components/EditEventForm/index.tsx
+++ b/src/admin/components/EditEventForm/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, FocusEventHandler, ChangeEventHandler, FormEventHandl
 import { Form, Input, Button, Select, DatePicker, TimePicker, Upload } from 'antd';
 import { useParams, useHistory } from 'react-router-dom';
 import * as moment from 'moment';
-import { notify } from '../../../utils';
 
 import './style.less';
 
@@ -55,9 +54,7 @@ const EditEventForm: React.FC<EditEventFormProps> = (props) => {
       .then(() => {
         history.push('/');
       })
-      .catch((error: string) => {
-        notify('Failed to delete the event', error);
-      });
+      .catch(() => {});
   };
 
   useEffect(() => {


### PR DESCRIPTION
The logic for checking if an event was deleted was outdated since the number of deleted events is no longer sent by the backend. In addition, the notification for that particular route was duplicated between the api function and the actual api call.

Resolves #447.