### PR TITLE
Profile Routing Improvements

### DIFF
--- a/src/layout/components/NavBarHorizontal/index.tsx
+++ b/src/layout/components/NavBarHorizontal/index.tsx
@@ -19,7 +19,7 @@ export default () => {
         <NavLink activeClassName="selected" to="/leaderboard">
           <NavTileItem icon={LBIcon} text="Leaderboard" />
         </NavLink>
-        <NavLink activeClassName="selected" to="/profile">
+        <NavLink exact activeClassName="selected" to="/profile">
           <NavTileItem icon={ProfileIcon} text="Profile" />
         </NavLink>
         <NavLink activeClassName="selected" to="/discord">

--- a/src/layout/components/NavBarVertical/index.tsx
+++ b/src/layout/components/NavBarVertical/index.tsx
@@ -38,7 +38,7 @@ const NavbarVertical: React.FC<NavbarVerticalProps> = (props) => {
           <NavLink activeClassName="selected" to="/leaderboard">
             <NavListItem icon={LBIcon} text="Leaderboard" />
           </NavLink>
-          <NavLink activeClassName="selected" to="/profile">
+          <NavLink exact activeClassName="selected" to="/profile">
             <NavListItem icon={ProfileIcon} text="Profile" />
           </NavLink>
           <NavLink activeClassName="selected" to="/about">

--- a/src/leaderboard/components/LeaderListItem/index.tsx
+++ b/src/leaderboard/components/LeaderListItem/index.tsx
@@ -12,10 +12,11 @@ interface LeaderListItemProps {
   placement: number;
   uuid: string;
   rank: number;
+  selfUUID: string;
 }
 
 const LeaderListItem: React.FC<LeaderListItemProps> = (props) => {
-  const { exp, image, name, placement, uuid } = props;
+  const { exp, image, name, placement, uuid, selfUUID } = props;
 
   return (
     <div
@@ -26,7 +27,7 @@ const LeaderListItem: React.FC<LeaderListItemProps> = (props) => {
       <Avatar size={40} src={image} />
       <span className="column left">
         <div className="name">
-          <Link to={`/profile/${uuid}`}>{name}</Link>
+          <Link to={uuid === selfUUID ? '/profile' : `/profile/${uuid}`}>{name}</Link>
         </div>
         <div className="rank mobile">{getRank(exp)}</div>
       </span>

--- a/src/leaderboard/components/TopLeaderCard/index.tsx
+++ b/src/leaderboard/components/TopLeaderCard/index.tsx
@@ -11,10 +11,11 @@ interface TopLeaderCardProps {
   placement: number;
   uuid: string;
   rank: number;
+  selfUUID: string;
 }
 
 const TopLeaderCard: React.FC<TopLeaderCardProps> = (props) => {
-  const { exp, name, image, placement, uuid } = props;
+  const { exp, name, image, placement, uuid, selfUUID } = props;
 
   let leaderboardClass = 'leaderboard-card ';
 
@@ -40,7 +41,7 @@ const TopLeaderCard: React.FC<TopLeaderCardProps> = (props) => {
             <Avatar size={80} src={image} />
           </div>
           <h1 className="name">
-            <Link to={`/profile/${uuid}`}>{name}</Link>
+            <Link to={uuid === selfUUID ? '/profile' : `/profile/${uuid}`}>{name}</Link>
           </h1>
           <h3>{getRank(exp)}</h3>
           <h2>{exp} points</h2>

--- a/src/leaderboard/containers/FourAndMore.tsx
+++ b/src/leaderboard/containers/FourAndMore.tsx
@@ -20,9 +20,10 @@ interface FourAndMoreContainerProps {
     },
   ];
   fetchLeaderboard: Function;
+  selfUUID: string;
 }
 
-const getFourAndMore = (users: { [key: string]: any }) => {
+const getFourAndMore = (users: { [key: string]: any }, selfUUID) => {
   const fourAndMore: any[] = [];
 
   for (let i = 3; i < users.length; i += 1) {
@@ -36,6 +37,7 @@ const getFourAndMore = (users: { [key: string]: any }) => {
         placement={i + 1}
         rank={user.rank}
         uuid={user.uuid}
+        selfUUID={selfUUID}
       />,
     );
   }
@@ -45,7 +47,7 @@ const getFourAndMore = (users: { [key: string]: any }) => {
 
 const LIMIT = 100;
 const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
-  const { users } = props;
+  const { users, selfUUID } = props;
   const [page, setPage] = useState(0);
   const [prevUserLength, setPrevUserLength] = useState(0);
   const [timeframe, setTimeframe] = useState('All Time');
@@ -126,7 +128,7 @@ const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
         </p>
       </Dropdown>
       <InfiniteScroll pageStart={0} loadMore={loadFunc} hasMore={hasMore()}>
-        {getFourAndMore(users)}
+        {getFourAndMore(users, selfUUID)}
       </InfiniteScroll>
     </>
   );
@@ -134,6 +136,7 @@ const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   users: state.leaderboard.users,
+  selfUUID: state.auth.profile.uuid,
 });
 
 export default connect(mapStateToProps, { fetchLeaderboard })(FourAndMoreContainer);

--- a/src/leaderboard/containers/TopThree.tsx
+++ b/src/leaderboard/containers/TopThree.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import TopLeaderCard from '../components/TopLeaderCard';
 import fetchLeaderboardConnect from '../leaderboardActions';
 
-const getTopThree = (users: { [key: string]: any }) => {
+const getTopThree = (users: { [key: string]: any }, selfUUID) => {
   const topThree: any[] = [];
   for (let i = 0; i < Math.min(users.length, 3); i += 1) {
     const user = users[i];
@@ -17,6 +17,7 @@ const getTopThree = (users: { [key: string]: any }) => {
         placement={i + 1}
         rank={user.rank}
         uuid={user.uuid}
+        selfUUID={selfUUID}
       />,
     );
   }
@@ -36,20 +37,22 @@ interface TopThreeContainerProps {
     },
   ];
   fetchLeaderboard: Function;
+  selfUUID: string;
 }
 
 const TopThreeContainer: React.FC<TopThreeContainerProps> = (props) => {
-  const { users, fetchLeaderboard } = props;
+  const { users, fetchLeaderboard, selfUUID } = props;
 
   useEffect(() => {
     fetchLeaderboard(0, 3);
   }, [fetchLeaderboard]);
 
-  return <>{getTopThree(users)}</>;
+  return <>{getTopThree(users, selfUUID)}</>;
 };
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   users: state.leaderboard.users,
+  selfUUID: state.auth.profile.uuid,
 });
 
 export default connect(mapStateToProps, { fetchLeaderboard: fetchLeaderboardConnect })(TopThreeContainer);

--- a/src/profile/components/ProfileUpdate/index.tsx
+++ b/src/profile/components/ProfileUpdate/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef, FocusEventHandler, ChangeEventHandl
 import { Form, Input, Button, Select, Modal, Avatar } from 'antd';
 import * as ANTD from 'antd';
 import { UploadOutlined } from '@ant-design/icons';
+import { useHistory } from 'react-router-dom';
 import { getDefaultProfile } from '../../../utils';
 import { uploadUserImage } from '../../profileActions';
 
@@ -42,6 +43,8 @@ interface ProfileUpdateProps {
 
 const ProfileUpdate: React.FC<ProfileUpdateProps> = (props) => {
   const { handleBlur, handleChange, handleSubmit, setFieldValue, user, values } = props;
+
+  const history = useHistory();
 
   const [bg, setBG] = useState(user.profile.profilePicture);
   const [fileList, setFileList] = useState([] as any[]);
@@ -191,7 +194,7 @@ const ProfileUpdate: React.FC<ProfileUpdateProps> = (props) => {
           <Button type="primary" htmlType="submit" className="save-button">
             Save Profile Changes
           </Button>
-          <Button type="danger" className="discard-button">
+          <Button type="danger" className="discard-button" onClick={() => history.push('/profile')}>
             Discard
           </Button>
         </form>


### PR DESCRIPTION
Couple small profile improvements:

- The discard button on the edit profile page redirects to the profile page.
- The profile item in the nav bar only highlights when the user profile is viewing their own profile.
- If a user selects themself in the leaderboard, it takes them to the profile page, not their public profile.

Resolves #407.