### PR TITLE
Clip long URL's in EventCard field

### DIFF
--- a/src/event/components/EventCard/styles.less
+++ b/src/event/components/EventCard/styles.less
@@ -55,11 +55,15 @@
 
       .location {
         opacity: 0.8;
+        overflow: hidden;
+        text-overflow: ellipsis;
         white-space: nowrap;
+        width: 100%;
       }
 
       .link {
         color: @blue-2;
+        display: block;
       }
 
       .title {


### PR DESCRIPTION
Long URL's or locations overflow off of the event card and
do not display. Clip them by overflowing them with an ellipsis.