### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{ts,tsx}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
`.editorconfig` provides automatic adherence to indentation for code editors that do not directly support ESLint. Useful for Sublime Text, Vim, Emacs, etc.