### PR TITLE
Update profile picture URL on fetch

### DIFF
--- a/src/profile/components/ProfileUpdate/index.tsx
+++ b/src/profile/components/ProfileUpdate/index.tsx
@@ -93,6 +93,7 @@ const ProfileUpdate: React.FC<ProfileUpdateProps> = (props) => {
     keys.forEach((key) => {
       setFieldValue(key, user.profile[key]);
     });
+    setBG(user.profile.profilePicture);
   }, [user, setFieldValue]);
 
   const InnerRefButton = ANTD.Button as React.ComponentClass<any>;

--- a/src/profile/components/ProfileUpdate/index.tsx
+++ b/src/profile/components/ProfileUpdate/index.tsx
@@ -3,8 +3,10 @@ import { Form, Input, Button, Select, Modal, Avatar } from 'antd';
 import * as ANTD from 'antd';
 import { UploadOutlined } from '@ant-design/icons';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { getDefaultProfile } from '../../../utils';
 import { uploadUserImage } from '../../profileActions';
+import { fetchUser } from '../../../auth/authActions';
 
 import majorsData from '../../../constants/majors.json';
 
@@ -45,6 +47,7 @@ const ProfileUpdate: React.FC<ProfileUpdateProps> = (props) => {
   const { handleBlur, handleChange, handleSubmit, setFieldValue, user, values } = props;
 
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const [bg, setBG] = useState(user.profile.profilePicture);
   const [fileList, setFileList] = useState([] as any[]);
@@ -83,6 +86,7 @@ const ProfileUpdate: React.FC<ProfileUpdateProps> = (props) => {
       .then(() => {
         setUploadState('none');
         setVisible(false);
+        dispatch(fetchUser());
       })
       .catch(() => {
         setUploadState('none');

--- a/src/profile/containers/ProfileUpdate.tsx
+++ b/src/profile/containers/ProfileUpdate.tsx
@@ -3,6 +3,7 @@ import { withFormik } from 'formik';
 
 import ProfileUpdate from '../components/ProfileUpdate';
 import { updateProfile } from '../profileActions';
+import { fetchUser } from '../../auth/authActions';
 
 const FormikProfileUpdate = withFormik({
   mapPropsToValues() {
@@ -17,7 +18,9 @@ const FormikProfileUpdate = withFormik({
   handleSubmit(values, { props }: { [key: string]: any }) {
     props
       .updateProfile(values)
-      .then(() => {})
+      .then(() => {
+          props.fetchUser();
+        })
       .catch(() => {});
   },
 })(ProfileUpdate as React.FC);
@@ -26,4 +29,4 @@ const mapStateToProps = (state: { [key: string]: any }) => ({
   user: state.auth,
 });
 
-export default connect(mapStateToProps, { updateProfile })(FormikProfileUpdate);
+export default connect(mapStateToProps, { updateProfile, fetchUser })(FormikProfileUpdate);

--- a/src/profile/containers/ProfileUpdate.tsx
+++ b/src/profile/containers/ProfileUpdate.tsx
@@ -19,8 +19,8 @@ const FormikProfileUpdate = withFormik({
     props
       .updateProfile(values)
       .then(() => {
-          props.fetchUser();
-        })
+        props.fetchUser();
+      })
       .catch(() => {});
   },
 })(ProfileUpdate as React.FC);

--- a/src/profile/profileActions.ts
+++ b/src/profile/profileActions.ts
@@ -40,7 +40,6 @@ export const uploadUserImage = async (file: string | Blob) => {
       });
 
       notify('Updated profile picture!', '');
-
       resolve(data);
     } catch (error) {
       notify('Unable to update profile picture!', error.message);


### PR DESCRIPTION
resolves #198, resolves #412, resolves #433

Updates profile picture URL after user profile has been fetched. Avatar was using a stale value before (the initial profile picture from redux store).