### PR TITLE
Add persistence to filters for Past Events and Leaderboard

### DIFF
--- a/src/event/containers/PastEvents.tsx
+++ b/src/event/containers/PastEvents.tsx
@@ -7,7 +7,11 @@ import EventCard from '../components/EventCard';
 import EventsList from '../components/EventsList';
 import background from '../../assets/graphics/background.svg';
 import { ReactComponent as ArrowsIcon } from '../../assets/icons/caret-icon-double.svg';
-import { fetchAttendance as fetchAttendanceConnect, fetchPastEvents as fetchPastEventsConnect } from '../eventActions';
+import {
+  fetchAttendance as fetchAttendanceConnect,
+  fetchPastEvents as fetchPastEventsConnect,
+  updateTimeframe as updateTimeframeConnect,
+} from '../eventActions';
 import { formatDate } from '../../utils';
 
 interface PastEventsContainerProps {
@@ -42,12 +46,12 @@ interface PastEventsContainerProps {
   ];
   fetchAttendance: Function;
   fetchPastEvents: Function;
+  updateTimeframe: Function;
+  timeframe: string;
 }
 
 const PastEventsContainer: React.FC<PastEventsContainerProps> = (props) => {
-  const { auth, events, attendance, fetchAttendance, fetchPastEvents } = props;
-
-  const [timeframe, setTimeframe] = useState('All Time');
+  const { auth, events, attendance, fetchAttendance, fetchPastEvents, timeframe, updateTimeframe } = props;
   const [shownEvents, setShownEvents] = useState<any[]>(events);
 
   useEffect(() => {
@@ -90,7 +94,7 @@ const PastEventsContainer: React.FC<PastEventsContainerProps> = (props) => {
               role="menuitem"
               className="leader-timeframe"
               onClick={() => {
-                setTimeframe(yearCode);
+                updateTimeframe(yearCode);
                 setShownEvents(yearFilteredEvents);
               }}
               tabIndex={0}
@@ -138,9 +142,11 @@ const mapStateToProps = (state: { [key: string]: any }) => ({
   events: state.event.pastEvents,
   auth: state.auth,
   attendance: state.event.attendance,
+  timeframe: state.event.timeframe,
 });
 
 export default connect(mapStateToProps, {
   fetchAttendance: fetchAttendanceConnect,
   fetchPastEvents: fetchPastEventsConnect,
+  updateTimeframe: updateTimeframeConnect,
 })(PastEventsContainer);

--- a/src/event/eventActions.ts
+++ b/src/event/eventActions.ts
@@ -6,6 +6,7 @@ import {
   FETCH_EVENT,
   FETCH_FUTURE_EVENTS,
   FETCH_PAST_EVENTS,
+  UPDATE_TIMEFRAME,
   ThunkActionCreator,
 } from './eventTypes';
 
@@ -109,6 +110,13 @@ export const checkIn: ThunkActionCreator = (info) => async (dispatch) => {
 export const checkOut: ThunkActionCreator = () => (dispatch) => {
   dispatch({
     type: EVENT_CHECKOUT,
+  });
+};
+
+export const updateTimeframe: ThunkActionCreator = (timeframe) => (dispatch) => {
+  dispatch({
+    type: UPDATE_TIMEFRAME,
+    payload: timeframe,
   });
 };
 

--- a/src/event/eventReducer.ts
+++ b/src/event/eventReducer.ts
@@ -1,7 +1,16 @@
 import _ from 'lodash';
 
 import { AnyAction } from 'redux';
-import { EVENT_CHECKIN, EVENT_CHECKOUT, EVENT_ERROR, FETCH_ATTENDANCE, FETCH_FUTURE_EVENTS, FETCH_PAST_EVENTS, FETCH_EVENT } from './eventTypes';
+import {
+  EVENT_CHECKIN,
+  EVENT_CHECKOUT,
+  EVENT_ERROR,
+  FETCH_ATTENDANCE,
+  FETCH_FUTURE_EVENTS,
+  FETCH_PAST_EVENTS,
+  FETCH_EVENT,
+  UPDATE_TIMEFRAME,
+} from './eventTypes';
 
 const initialState = {
   attendance: [],
@@ -10,6 +19,7 @@ const initialState = {
   futureEvents: [],
   pastEvents: [],
   checkin: false,
+  timeframe: 'All Time',
   error: null,
 };
 
@@ -46,6 +56,12 @@ const EventsReducer = (state = initialState, action: AnyAction) => {
       return {
         ...state,
         pastEvents: action.payload,
+      };
+
+    case UPDATE_TIMEFRAME:
+      return {
+        ...state,
+        timeframe: action.payload,
       };
 
     case FETCH_EVENT:

--- a/src/event/eventTypes.ts
+++ b/src/event/eventTypes.ts
@@ -8,5 +8,6 @@ export const FETCH_ATTENDANCE = 'FETCH_ATTENDANCE';
 export const FETCH_EVENT = 'FETCH_EVENT';
 export const FETCH_FUTURE_EVENTS = 'FETCH_FUTURE_EVENTS';
 export const FETCH_PAST_EVENTS = 'FETCH_PAST_EVENTS';
+export const UPDATE_TIMEFRAME = 'UPDATE_TIMEFRAME';
 
 export type ThunkActionCreator = ActionCreator<ThunkAction<void, {}, {}, AnyAction>>;

--- a/src/leaderboard/containers/FourAndMore.tsx
+++ b/src/leaderboard/containers/FourAndMore.tsx
@@ -5,7 +5,7 @@ import { getYearBounds, years } from 'ucsd-quarters-years';
 import InfiniteScroll from 'react-infinite-scroller';
 import { Menu, Dropdown } from 'antd';
 import LeaderListItem from '../components/LeaderListItem';
-import fetchLeaderboard from '../leaderboardActions';
+import { fetchLeaderboard as fetchLeaderboardConnect, updateTimeframe as updateTimeframeConnect } from '../leaderboardActions';
 
 import { ReactComponent as ArrowsIcon } from '../../assets/icons/caret-icon-double.svg';
 
@@ -21,7 +21,9 @@ interface FourAndMoreContainerProps {
     },
   ];
   fetchLeaderboard: Function;
+  updateTimeframe: Function;
   selfUUID: string;
+  timeframe: string;
 }
 
 const getFourAndMore = (users: { [key: string]: any }, selfUUID) => {
@@ -48,10 +50,9 @@ const getFourAndMore = (users: { [key: string]: any }, selfUUID) => {
 
 const LIMIT = 100;
 const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
-  const { users, selfUUID } = props;
+  const { users, selfUUID, timeframe, updateTimeframe } = props;
   const [page, setPage] = useState(0);
   const [prevUserLength, setPrevUserLength] = useState(0);
-  const [timeframe, setTimeframe] = useState('All Time');
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(0);
 
@@ -75,23 +76,34 @@ const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
     }
   };
 
+  const yearCodes = ['All Time'].concat(Object.keys(years));
   const menu = (
     <Menu>
-      {Object.keys(years).map((year, index) => {
+      {yearCodes.map((yearCode, index) => {
         return (
-          <Menu.Item key={year}>
+          <Menu.Item key={yearCode}>
             <div
               role="menuitem"
               className="leader-timeframe"
               tabIndex={0}
               onClick={() => {
-                const timeframeStart = getYearBounds(year as any).start;
+                if (yearCode === 'All Time') {
+                  updateTimeframe(yearCode);
+                  setStartTime(0);
+                  setEndTime(0);
+                  setPage(0);
+                  props.fetchLeaderboard(0, 3, true); // updates users for TopThree
+                  props.fetchLeaderboard(3, LIMIT); // updates users for FourAndMore
+                  return;
+                }
+                const timeframeStart = getYearBounds(yearCode as any).start;
                 // If the next year does exist, use its start date as the timeframe bound
                 // (to include summertime in previous year), otherwise just use the current yearly bound.
-                const timeframeEnd = years[index + 1] !== null ? getYearBounds(years[index + 1] as any).start : getYearBounds(year as any).end;
+                const timeframeEnd =
+                  years[index + 1] !== undefined ? getYearBounds(years[index + 1] as any).start : getYearBounds(yearCode as any).end;
                 const yearUnixStart = timeframeStart.getTime() / 1000;
                 const yearUnixEnd = timeframeEnd.getTime() / 1000;
-                setTimeframe(year);
+                updateTimeframe(yearCode);
                 setStartTime(yearUnixStart);
                 setEndTime(yearUnixEnd);
                 setPage(0);
@@ -99,7 +111,7 @@ const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
                 props.fetchLeaderboard(3, LIMIT, yearUnixStart, yearUnixEnd); // updates users for FourAndMore
               }}
             >
-              {year}
+              {yearCode}
             </div>
           </Menu.Item>
         );
@@ -123,7 +135,8 @@ const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   users: state.leaderboard.users,
+  timeframe: state.leaderboard.timeframe,
   selfUUID: state.auth.profile.uuid,
 });
 
-export default connect(mapStateToProps, { fetchLeaderboard })(FourAndMoreContainer);
+export default connect(mapStateToProps, { fetchLeaderboard: fetchLeaderboardConnect, updateTimeframe: updateTimeframeConnect })(FourAndMoreContainer);

--- a/src/leaderboard/containers/FourAndMore.tsx
+++ b/src/leaderboard/containers/FourAndMore.tsx
@@ -80,6 +80,11 @@ const FourAndMoreContainer: React.FC<FourAndMoreContainerProps> = (props) => {
   const menu = (
     <Menu>
       {yearCodes.map((yearCode, index) => {
+        // if this academic quarter start hasn't at least started...
+        if (yearCode !== 'All Time' && !(getYearBounds(yearCode as any).start < new Date())) {
+          // do not output a menu option at all.ls
+          return null;
+        }
         return (
           <Menu.Item key={yearCode}>
             <div

--- a/src/leaderboard/containers/TopThree.tsx
+++ b/src/leaderboard/containers/TopThree.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import TopLeaderCard from '../components/TopLeaderCard';
-import fetchLeaderboardConnect from '../leaderboardActions';
+import { fetchLeaderboard as fetchLeaderboardConnect } from '../leaderboardActions';
 
 const getTopThree = (users: { [key: string]: any }, selfUUID) => {
   const topThree: any[] = [];

--- a/src/leaderboard/leaderboardActions.ts
+++ b/src/leaderboard/leaderboardActions.ts
@@ -1,10 +1,10 @@
-import { CLEAR_LEADERBOARD, FETCH_LEADERBOARD, LEADERBOARD_ERROR, ThunkActionCreator } from './leaderboardTypes';
+import { CLEAR_LEADERBOARD, FETCH_LEADERBOARD, LEADERBOARD_ERROR, UPDATE_TIMEFRAME, ThunkActionCreator } from './leaderboardTypes';
 import { logoutUser } from '../auth/authActions';
 
 import Config from '../config';
 import { fetchService } from '../utils';
 
-const fetchLeaderboard: ThunkActionCreator = (offset: number = 0, limit: number, from?: number, to?: number, resetUsers?: boolean) => async (
+export const fetchLeaderboard: ThunkActionCreator = (offset: number = 0, limit: number, from?: number, to?: number, resetUsers?: boolean) => async (
   dispatch,
 ) => {
   try {
@@ -35,4 +35,9 @@ const fetchLeaderboard: ThunkActionCreator = (offset: number = 0, limit: number,
   }
 };
 
-export default fetchLeaderboard;
+export const updateTimeframe: ThunkActionCreator = (timeframe) => (dispatch) => {
+  dispatch({
+    type: UPDATE_TIMEFRAME,
+    payload: timeframe,
+  });
+};

--- a/src/leaderboard/leaderboardReducer.ts
+++ b/src/leaderboard/leaderboardReducer.ts
@@ -1,11 +1,12 @@
 import { AnyAction } from 'redux';
-import { CLEAR_LEADERBOARD, FETCH_LEADERBOARD, LEADERBOARD_ERROR } from './leaderboardTypes';
+import { CLEAR_LEADERBOARD, FETCH_LEADERBOARD, LEADERBOARD_ERROR, UPDATE_TIMEFRAME } from './leaderboardTypes';
 import { getDefaultProfile } from '../utils';
 
 const initialState = {
   users: [],
   /** Maps offset value used to the users fetched */
   offsetToUsers: new Map(),
+  timeframe: 'All Time',
 };
 
 const LeaderboardReducer = (state = initialState, action: AnyAction) => {
@@ -51,6 +52,13 @@ const LeaderboardReducer = (state = initialState, action: AnyAction) => {
         ...state,
         error: action.payload,
       };
+
+    case UPDATE_TIMEFRAME:
+      return {
+        ...state,
+        timeframe: action.payload,
+      };
+
     default:
       return state;
   }

--- a/src/leaderboard/leaderboardTypes.ts
+++ b/src/leaderboard/leaderboardTypes.ts
@@ -4,5 +4,6 @@ import { ActionCreator, AnyAction } from 'redux';
 export const FETCH_LEADERBOARD = 'FETCH_LEADERBOARD';
 export const LEADERBOARD_ERROR = 'LEADERBOARD_ERROR';
 export const CLEAR_LEADERBOARD = 'CLEAR_LEADERBOARD';
+export const UPDATE_TIMEFRAME = 'UPDATE_TIMEFRAME';
 
 export type ThunkActionCreator = ActionCreator<ThunkAction<void, {}, {}, AnyAction>>;


### PR DESCRIPTION
Resolves #469.

Fix persistence issue by adding `timeframe` state parameter to Redux store, so parameter persists across component unloads. Both Past Events and Leaderboard are fixed, as they use a similar mechanic.