### PR TITLE
Cart Restructure

### DIFF
--- a/src/store/components/ItemPage/index.tsx
+++ b/src/store/components/ItemPage/index.tsx
@@ -79,7 +79,7 @@ const ItemPage: React.FC<ItemPageProps> = (props) => {
             <StoreButton
               text="Add to Cart"
               onClick={() => {
-                props.addToCart(currentOption, currentQuantity);
+                props.addToCart({ item, optionUUID: currentOption, quantity: currentQuantity });
               }}
             />
           </div>

--- a/src/store/components/NavigationBar/index.tsx
+++ b/src/store/components/NavigationBar/index.tsx
@@ -9,6 +9,7 @@ import BackArrow from '../../../assets/icons/back-arrow.svg';
 import CartIcon from '../../../assets/icons/cart-icon.svg';
 
 import './style.less';
+import { CartItem } from '../../../types';
 
 interface NavigationBarProps {
   home?: boolean;
@@ -47,14 +48,14 @@ const NavigationBar: React.FC<NavigationBarProps> = (props) => {
 const getCartSize = (cart: any) => {
   let size = 0;
 
-  const entries: [string, number][] = Object.entries(cart);
+  const entries: [string, CartItem][] = Object.entries(cart);
 
   if (entries.length === 0) {
     return 0;
   }
 
   for (let i = 0; i < entries.length; i += 1) {
-    size += entries[i][1];
+    size += entries[i][1].quantity;
   }
 
   return size;

--- a/src/store/storeActions.ts
+++ b/src/store/storeActions.ts
@@ -2,6 +2,7 @@ import { CART_ADD, CART_EDIT, CART_REMOVE, ThunkActionCreator } from './storeTyp
 import { fetchService } from '../utils';
 import Config from '../config';
 import { logoutUser } from '../auth/authActions';
+import { CartItem } from '../types';
 
 export const fetchCollections: ThunkActionCreator = () => async (dispatch) => {
   return new Promise(async (resolve, reject) => {
@@ -39,23 +40,23 @@ export const fetchItem: ThunkActionCreator = (uuid: string) => async (dispatch) 
   });
 };
 
-export const addToCart: ThunkActionCreator = (uuid: string, quantity: number) => (dispatch) => {
+export const addToCart: ThunkActionCreator = (cartItem: CartItem) => (dispatch) => {
   dispatch({
     type: CART_ADD,
-    payload: { uuid, quantity },
+    payload: cartItem,
   });
 };
 
-export const editInCart: ThunkActionCreator = (uuid: string, quantity: number) => (dispatch) => {
+export const editInCart: ThunkActionCreator = (cartItem: CartItem) => (dispatch) => {
   dispatch({
     type: CART_EDIT,
-    payload: { uuid, quantity },
+    payload: cartItem,
   });
 };
 
-export const removeFromCart: ThunkActionCreator = (uuid: string) => (dispatch) => {
+export const removeFromCart: ThunkActionCreator = (cartItem: CartItem) => (dispatch) => {
   dispatch({
     type: CART_REMOVE,
-    payload: { uuid },
+    payload: cartItem,
   });
 };

--- a/src/store/storeReducer.ts
+++ b/src/store/storeReducer.ts
@@ -1,5 +1,6 @@
 import { AnyAction } from 'redux';
 import { CART_ADD, CART_EDIT, CART_REMOVE } from './storeTypes';
+import { CartItem } from '../types';
 
 const initialState = {
   error: false,
@@ -9,53 +10,61 @@ const initialState = {
 const StoreReducer = (state = initialState, action: AnyAction) => {
   switch (action.type) {
     case CART_ADD: {
-      const { uuid, quantity } = action.payload;
+      const { optionUUID, quantity }: CartItem = action.payload;
 
-      if (!uuid || quantity < 1) {
+      if (!optionUUID || quantity < 1) {
         return state;
       }
 
       const newCart = { ...state.cart };
 
-      if (newCart[uuid]) {
-        newCart[uuid] += quantity;
+      if (newCart[optionUUID]) {
+        // Item exists, no need to save item data
+        newCart[optionUUID].quantity += quantity;
       } else {
-        newCart[uuid] = quantity;
+        // Item doesn't exist, need to save item data
+        newCart[optionUUID] = action.payload;
       }
+
+      localStorage.setItem('cart', JSON.stringify(newCart));
 
       const newState = { ...initialState, cart: newCart };
 
       return newState;
     }
     case CART_EDIT: {
-      const { uuid, quantity } = action.payload;
+      const { optionUUID, quantity }: CartItem = action.payload;
 
-      if (!uuid) {
+      if (!optionUUID) {
         return state;
       }
 
       const newCart = { ...state.cart };
 
       if (quantity > 0) {
-        newCart[uuid] = quantity;
+        newCart[optionUUID].quantity = quantity;
       } else {
-        delete newCart[uuid];
+        delete newCart[optionUUID];
       }
+
+      localStorage.setItem('cart', JSON.stringify(newCart));
 
       const newState = { ...initialState, cart: newCart };
 
       return newState;
     }
     case CART_REMOVE: {
-      const { uuid } = action.payload;
+      const { optionUUID }: CartItem = action.payload;
 
-      if (!uuid) {
+      if (!optionUUID) {
         return state;
       }
 
       const newCart = { ...state.cart };
 
-      delete newCart[uuid];
+      delete newCart[optionUUID];
+
+      localStorage.setItem('cart', JSON.stringify(newCart));
 
       const newState = { ...initialState, cart: newCart };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,12 @@ export interface MerchItemOptionMetadata {
   position: number;
 }
 
+export interface CartItem {
+  item: PublicMerchItem;
+  optionUUID: string;
+  quantity: number;
+}
+
 export interface PublicOrderItem {
   uuid: Uuid;
   option: PublicMerchItemOption;


### PR DESCRIPTION
The store cart now contains objects with the structure `{ item: PublicMerchItem; optionUUID: string; quantity: number; }`, so that the `CartDisplay` component can pull the item data locally, rather than needing to call an API route to retrieve the cart.