### PR TITLE
Cart updates

### DIFF
--- a/src/store/components/ItemPage/index.tsx
+++ b/src/store/components/ItemPage/index.tsx
@@ -51,10 +51,11 @@ const ItemPage: React.FC<ItemPageProps> = (props) => {
               <p className="item-option-header">{options[0].metadata ? options[0].metadata.type : ''}:</p>
               <OptionSelector
                 options={options.map((option) => {
-                  return { key: option.uuid, value: option.metadata ? option.metadata.value : '' };
+                  const { uuid: key, metadata } = option;
+                  return { key, label: metadata ? metadata.value : '', value: option };
                 })}
-                optionSelected={(option) => {
-                  setCurrentOption(option.key);
+                onChange={({ value }: { value: PublicMerchItemOption }) => {
+                  setCurrentOption(value);
                 }}
               />
             </div>
@@ -79,7 +80,7 @@ const ItemPage: React.FC<ItemPageProps> = (props) => {
             <StoreButton
               text="Add to Cart"
               onClick={() => {
-                props.addToCart({ item, optionUUID: currentOption, quantity: currentQuantity });
+                props.addToCart({ item, option: currentOption, quantity: currentQuantity });
               }}
             />
           </div>

--- a/src/store/components/OptionSelector/index.tsx
+++ b/src/store/components/OptionSelector/index.tsx
@@ -2,33 +2,34 @@ import React, { useState } from 'react';
 
 import './style.less';
 
+type Option = { key: string; label: string; value: any };
 interface OptionSelectorProps {
-  options: { key: string; value: string }[];
-  optionSelected: Function;
-  enabled?: boolean;
+  options: Option[];
+  onChange: (option: Option) => void;
+  disabled?: boolean;
   initialOption?: string;
 }
 
 const OptionSelector: React.FC<OptionSelectorProps> = (props) => {
-  const { options, optionSelected, enabled = true, initialOption } = props;
+  const { options, onChange, disabled = false, initialOption = '' } = props;
 
-  const [current, setCurrent] = useState<string | undefined>(initialOption);
+  const [current, setCurrent] = useState<string>(initialOption);
 
   return (
     <div className="option-selector">
       {options.map((option) => {
         return (
           <button
-            className={`option${option.key === current ? ' selected' : ''}`}
+            className={option.key === current ? 'option selected' : 'option'}
             type="button"
             key={option.key}
-            disabled={!enabled ? true : undefined}
+            disabled={disabled}
             onClick={() => {
               setCurrent(option.key);
-              optionSelected(option);
+              onChange(option);
             }}
           >
-            {option.value}
+            {option.label}
           </button>
         );
       })}

--- a/src/store/storeReducer.ts
+++ b/src/store/storeReducer.ts
@@ -4,26 +4,29 @@ import { CartItem } from '../types';
 
 const initialState = {
   error: false,
-  cart: JSON.parse(localStorage.getItem('cart') || '{}'),
+  cart: JSON.parse(localStorage.getItem('cart') || '{}') as { [uuid: string]: CartItem },
 };
 
 const StoreReducer = (state = initialState, action: AnyAction) => {
   switch (action.type) {
     case CART_ADD: {
-      const { optionUUID, quantity }: CartItem = action.payload;
+      const {
+        option: { uuid },
+        quantity,
+      }: CartItem = action.payload;
 
-      if (!optionUUID || quantity < 1) {
+      if (!uuid || quantity < 1) {
         return state;
       }
 
       const newCart = { ...state.cart };
 
-      if (newCart[optionUUID]) {
+      if (newCart[uuid]) {
         // Item exists, no need to save item data
-        newCart[optionUUID].quantity += quantity;
+        newCart[uuid].quantity += quantity;
       } else {
         // Item doesn't exist, need to save item data
-        newCart[optionUUID] = action.payload;
+        newCart[uuid] = action.payload;
       }
 
       localStorage.setItem('cart', JSON.stringify(newCart));
@@ -33,18 +36,21 @@ const StoreReducer = (state = initialState, action: AnyAction) => {
       return newState;
     }
     case CART_EDIT: {
-      const { optionUUID, quantity }: CartItem = action.payload;
+      const {
+        option: { uuid },
+        quantity,
+      }: CartItem = action.payload;
 
-      if (!optionUUID) {
+      if (!uuid) {
         return state;
       }
 
       const newCart = { ...state.cart };
 
       if (quantity > 0) {
-        newCart[optionUUID].quantity = quantity;
+        newCart[uuid].quantity = quantity;
       } else {
-        delete newCart[optionUUID];
+        delete newCart[uuid];
       }
 
       localStorage.setItem('cart', JSON.stringify(newCart));
@@ -54,15 +60,17 @@ const StoreReducer = (state = initialState, action: AnyAction) => {
       return newState;
     }
     case CART_REMOVE: {
-      const { optionUUID }: CartItem = action.payload;
+      const {
+        option: { uuid },
+      }: CartItem = action.payload;
 
-      if (!optionUUID) {
+      if (!uuid) {
         return state;
       }
 
       const newCart = { ...state.cart };
 
-      delete newCart[optionUUID];
+      delete newCart[uuid];
 
       localStorage.setItem('cart', JSON.stringify(newCart));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface MerchItemOptionMetadata {
 
 export interface CartItem {
   item: PublicMerchItem;
-  optionUUID: string;
+  option: PublicMerchItemOption;
   quantity: number;
 }
 


### PR DESCRIPTION
This PR refactors `CartItem` and `state.store.cart` (Redux store) to hold `PublicMerchItemOption` and all of the relevant metadata instead of the just the option UUID. Storing option UUIDs made sense when used in conjunction with the [`getCart` endpoint ](https://github.com/acmucsd/membership-portal/pull/209) but since we're storing the entire cart metadata on the client-side, it makes more sense to fill the Redux store with that metadata as well. It also makes it more convenient for the `CartDisplay` as the option metadata doesn't need to be unnecessarily searched for.

The store reducer and client dispatcher (`ItemPage`) have been updated to reflect these changes. `OptionSelector` has also been refactored to support this change with some extensibility and type safety tweaks.