### PR TITLE
Added Modal for the fulfill orders page

### DIFF
--- a/src/store/components/AdminFulfillPage/index.tsx
+++ b/src/store/components/AdminFulfillPage/index.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import React, { useState } from 'react';
 
+import { Modal } from 'antd';
 import { PublicOrder, PublicOrderPickupEvent } from '../../../types';
 
 import StoreButton from '../StoreButton';
@@ -22,6 +23,7 @@ const AdminFulfillPage: React.FC<AdminFulfillPageProps> = (props) => {
 
   const [uuid, setUuid] = useState<string>();
   const [selectedOrder, setSelectedOrder] = useState<PublicOrder>();
+  const [showModal, setShowModal] = useState(false);
 
   if (!pickupEvent) {
     return (
@@ -128,23 +130,28 @@ const AdminFulfillPage: React.FC<AdminFulfillPageProps> = (props) => {
             text="Finish Pickup Event"
             type="danger"
             onClick={async () => {
-              // TODO: Implement a proper modal. For now, this functions / ensures users don't accidentally complete the pickupEvent
-              // eslint-disable-next-line no-alert, no-restricted-globals
-              const doIt = confirm('This will end the pickup event forever. Did you mean to do this?');
-              if (doIt) {
-                const url = `${Config.API_URL}${Config.routes.store.order}/pickup/${pickupEvent.uuid}/complete`;
-
-                try {
-                  await fetchService(url, 'POST', 'json', {
-                    requiresAuthorization: true,
-                  });
-                  notify('Success!', 'Pickup Event is Over');
-                } catch (e) {
-                  notify('API Error', (e as any).message);
-                }
-              }
+              setShowModal(true);
             }}
           />
+          <Modal
+            visible={showModal}
+            onCancel={() => setShowModal(false)}
+            onOk={async () => {
+              setShowModal(false);
+              const url = `${Config.API_URL}${Config.routes.store.order}/pickup/${pickupEvent.uuid}/complete`;
+
+              try {
+                await fetchService(url, 'POST', 'json', {
+                  requiresAuthorization: true,
+                });
+                notify('Success!', 'Pickup Event is Over');
+              } catch (e) {
+                notify('API Error', (e as any).message);
+              }
+            }}
+          >
+            This will end the pickup event forever. Did you mean to do this?
+          </Modal>
         </div>
         {orderInfo}
       </div>

--- a/src/store/components/StoreImageUpload/index.tsx
+++ b/src/store/components/StoreImageUpload/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Upload } from 'antd';
 import { UploadChangeParam } from 'antd/lib/upload';
 import ImgCrop from 'antd-img-crop';


### PR DESCRIPTION
Before
<img width="479" alt="Screen Shot 2021-12-22 at 9 45 04 PM" src="https://user-images.githubusercontent.com/9388431/147193987-7fdfe203-6aaa-4723-95be-28ce53f7f643.png">
After
<img width="594" alt="Screen Shot 2021-12-22 at 9 45 20 PM" src="https://user-images.githubusercontent.com/9388431/147194031-02d684a0-2555-4a77-8df3-31ee2968cd67.png">

