### PR TITLE
Update loginUser Action

### DIFF
--- a/src/auth/authActions.ts
+++ b/src/auth/authActions.ts
@@ -51,10 +51,19 @@ export const loginUser: ThunkActionCreator = (values, search) => async (dispatch
       isAdmin: userData.admin,
     });
 
-    // Redirect to home on login.
-    if (search !== '') {
-      dispatch(replace(`/checkin${search}`));
+    const params = new URLSearchParams(search);
+
+    const code = params.get('code');
+    const destination = params.get('destination');
+
+    if (code) {
+      // If the user was signed out when trying to check in, direct them to the checkin page
+      dispatch(replace(`/checkin?code=${code}}`));
+    } else if (destination) {
+      // If the user was signed out when trying to access the site, return them to their desired destination
+      dispatch(replace(decodeURIComponent(destination)));
     } else {
+      // Otherwise, redirect to home
       dispatch(replace('/'));
     }
   } catch (error) {
@@ -119,8 +128,20 @@ export const verifyToken: ThunkActionCreator = (dispatch) => async (search, path
         notify('Not Authenticated', 'Please sign in or register for an account before continuing.');
       }
 
-      // redirerct to /login
-      dispatch(replace(`/login${search}`));
+      // redirerct to /login, while including the checkin code and desired destination if present
+      dispatch(
+        replace(
+          `/login${search}${
+            pathname.toString() !== '/'
+              ? `${
+                  search.toString()
+                    ? `&destination=${encodeURIComponent(pathname.toString())}`
+                    : `?destination=${encodeURIComponent(pathname.toString())}`
+                }`
+              : ''
+          }`,
+        ),
+      );
       resolve();
     }
   });

--- a/src/auth/containers/requireAdminAuth.tsx
+++ b/src/auth/containers/requireAdminAuth.tsx
@@ -6,7 +6,7 @@ import { replace } from 'connected-react-router';
 import { verifyToken } from '../authActions';
 
 const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
-  const { authenticated, pathname, search, verify, redirectHome } = props;
+  const { authenticated, pathname, search, verify, redirectHome, isAdmin } = props;
 
   useEffect(() => {
     // check if authenticated, if not, then verify the token
@@ -20,6 +20,9 @@ const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) =
           }
         })
         .catch(() => {});
+    } else if (!isAdmin) {
+      // if not an admin, redirect
+      redirectHome();
     }
   }, [authenticated, verify, redirectHome, search, pathname]);
 
@@ -31,6 +34,7 @@ const mapStateToProps = (state: { [key: string]: any }) => ({
   authenticated: state.auth.authenticated,
   pathname: state.router.location.pathname,
   search: state.router.location.search,
+  isAdmin: state.auth.admin,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -41,6 +45,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     return verifyToken(dispatch);
   },
 });
+
 const requireAdminAuth = compose(connect(mapStateToProps, mapDispatchToProps), withAdminAuth);
 
 export default requireAdminAuth;

--- a/src/auth/containers/requireAdminAuth.tsx
+++ b/src/auth/containers/requireAdminAuth.tsx
@@ -6,13 +6,13 @@ import { replace } from 'connected-react-router';
 import { verifyToken } from '../authActions';
 
 const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
-  const { authenticated, verify, redirectHome } = props;
+  const { authenticated, pathname, search, verify, redirectHome } = props;
 
   useEffect(() => {
     // check if authenticated, if not, then verify the token
     if (!authenticated) {
       // using then here because state doesn't update in right order
-      verify()()
+      verify()(search, pathname)
         .then((data: { [key: string]: any }) => {
           if (!data.admin) {
             // if not an admin, redirect
@@ -21,7 +21,7 @@ const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) =
         })
         .catch(() => {});
     }
-  }, [authenticated, verify, redirectHome]);
+  }, [authenticated, verify, redirectHome, search, pathname]);
 
   // TODO: Make redirecting screen and return that if not authenticated.
   return <Component />;
@@ -29,6 +29,8 @@ const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) =
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   authenticated: state.auth.authenticated,
+  pathname: state.router.location.pathname,
+  search: state.router.location.search,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({


### PR DESCRIPTION
If the user attempts to access a portal link directly and isn't signed in, they're redirected to the login page. After logging in, they're taken to the home page, rather than their previously desired destination. The `verifyToken` route now encodes the destination into the login URL, so that upon login, the user is taken to the correct destination.