### PR TITLE
Rename PageLayout Selector

### DIFF
--- a/src/layout/components/PageLayout/index.tsx
+++ b/src/layout/components/PageLayout/index.tsx
@@ -24,12 +24,12 @@ const PageLayout: React.FC<PageLayoutProps> = (props) => {
       {isMobile ? (
         <>
           <NavBarHorizontal />
-          <div className="content">{children}</div>
+          <div className="page-layout-content">{children}</div>
         </>
       ) : (
         <div className="content-table">
           <NavBarVertical isAdmin={isAdmin} />
-          <div className="content">{children}</div>
+          <div className="page-layout-content">{children}</div>
         </div>
       )}
     </>

--- a/src/layout/components/PageLayout/style.less
+++ b/src/layout/components/PageLayout/style.less
@@ -1,7 +1,7 @@
 @import '../../../styles/vars.less';
 @import '../../../styles/mixins.less';
 
-.content {
+.page-layout-content {
   overflow: hidden;
   padding: 4.5%;
   position: relative;

--- a/src/profile/components/ProfileCard/style.less
+++ b/src/profile/components/ProfileCard/style.less
@@ -43,7 +43,6 @@
     overflow-x: scroll;
     scrollbar-width: none;
     vertical-align: middle;
-    width: 120px;
   }
 
   .info::-webkit-scrollbar {


### PR DESCRIPTION
There was a class name overlap between the `PageLayout` selector and the profile cart class name, this rename resolves that issue as a quick fix.