### PR TITLE
Fix Incorrect Date Comparison

### DIFF
--- a/src/store/components/OrderPage/index.tsx
+++ b/src/store/components/OrderPage/index.tsx
@@ -39,7 +39,7 @@ const OrderPage: React.FC<OrderPageProps> = (props) => {
 
   if (status === OrderStatus.CANCELLED || status === OrderStatus.FULFILLED) {
     actionable = false;
-  } else if (status === OrderStatus.PLACED && new Date() < moment(pickupEvent.start).subtract(2, 'days').toDate()) {
+  } else if (status === OrderStatus.PLACED && new Date() > moment(pickupEvent.start).subtract(2, 'days').toDate()) {
     actionable = false;
   }
 


### PR DESCRIPTION
In order to determine that the current time is too close to the pickup event, the current time should be greater than the pickup start time minus two days, not less than.