### PR TITLE
Independent History

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "antd": "3.24.3",
     "antd-img-crop": "^4.0.2",
     "babel-plugin-import": "^1.12.0",
-    "connected-react-router": "^6.5.2",
     "copy-to-clipboard": "^3.3.1",
     "customize-cra": "^0.8.0",
     "formik": "^2.0.3",

--- a/src/auth/authActions.ts
+++ b/src/auth/authActions.ts
@@ -1,4 +1,3 @@
-import { replace } from 'connected-react-router';
 import {
   AUTH_ERROR,
   AUTH_USER,
@@ -12,6 +11,7 @@ import {
 } from './authTypes';
 
 import Config from '../config';
+import history from '../history';
 import Storage from '../storage';
 import { notify, fetchService } from '../utils';
 
@@ -58,13 +58,13 @@ export const loginUser: ThunkActionCreator = (values, search) => async (dispatch
 
     if (code) {
       // If the user was signed out when trying to check in, direct them to the checkin page
-      dispatch(replace(`/checkin?code=${code}}`));
+      history.replace(`/checkin?code=${code}}`);
     } else if (destination) {
       // If the user was signed out when trying to access the site, return them to their desired destination
-      dispatch(replace(decodeURIComponent(destination)));
+      history.replace(decodeURIComponent(destination));
     } else {
       // Otherwise, redirect to home
-      dispatch(replace('/'));
+      history.replace('/');
     }
   } catch (error) {
     notify('Unable to login!', error.message);
@@ -92,7 +92,7 @@ export const verifyToken: ThunkActionCreator = (dispatch) => async (search, path
           });
           notify('Login expired', 'Please sign in again');
           // redirect to /login
-          dispatch(replace(`/login${search}`));
+          history.replace(`/login${search}`);
           resolve(data);
           return;
         }
@@ -116,7 +116,7 @@ export const verifyToken: ThunkActionCreator = (dispatch) => async (search, path
           type: UNAUTH_USER,
         });
         // redirerct to /login
-        dispatch(replace(`/login${search}`));
+        history.replace(`/login${search}`);
         reject(error);
       }
     } else {
@@ -130,18 +130,16 @@ export const verifyToken: ThunkActionCreator = (dispatch) => async (search, path
       }
 
       // redirerct to /login, while including the checkin code and desired destination if present
-      dispatch(
-        replace(
-          `/login${search}${
-            pathname.toString() !== '/'
-              ? `${
-                  search.toString()
-                    ? `&destination=${encodeURIComponent(pathname.toString())}`
-                    : `?destination=${encodeURIComponent(pathname.toString())}`
-                }`
-              : ''
-          }`,
-        ),
+      history.replace(
+        `/login${search}${
+          pathname.toString() !== '/'
+            ? `${
+                search.toString()
+                  ? `&destination=${encodeURIComponent(pathname.toString())}`
+                  : `?destination=${encodeURIComponent(pathname.toString())}`
+              }`
+            : ''
+        }`,
       );
       resolve();
     }
@@ -153,7 +151,7 @@ export const logoutUser: ThunkActionCreator = () => (dispatch) => {
     type: UNAUTH_USER,
   });
   Storage.remove('token');
-  dispatch(replace('/login'));
+  history.replace('/login');
 };
 
 export const passwordReset: ThunkActionCreator = (email: string) => async (dispatch) => {
@@ -180,7 +178,7 @@ export const passwordReset: ThunkActionCreator = (email: string) => async (dispa
   }
 };
 
-export const updatePassword: ThunkActionCreator = (user) => async (dispatch) => {
+export const updatePassword: ThunkActionCreator = (user) => async () => {
   try {
     const url = `${Config.API_URL}${Config.routes.auth.resetPassword}/${user.code}`;
     await fetchService(url, 'POST', 'json', {
@@ -188,7 +186,7 @@ export const updatePassword: ThunkActionCreator = (user) => async (dispatch) => 
       payload: JSON.stringify({ user }),
     });
 
-    dispatch(replace('/'));
+    history.replace('/');
   } catch (error) {
     notify('Unable to reset password!', error.message);
   }
@@ -254,8 +252,8 @@ export const registerAccount: ThunkActionCreator = (user, search) => async (disp
   }
 };
 
-export const redirectAuth: ThunkActionCreator = () => (dispatch) => {
-  dispatch(replace('/authenticate-email'));
+export const redirectAuth: ThunkActionCreator = () => () => {
+  history.replace('/authenticate-email');
 };
 
 export const fetchUser: ThunkActionCreator = (uuid) => async (dispatch) => {

--- a/src/auth/containers/RegisterForm.tsx
+++ b/src/auth/containers/RegisterForm.tsx
@@ -4,6 +4,7 @@ import * as Yup from 'yup';
 
 import RegisterForm from '../components/RegisterForm';
 import { registerAccount } from '../authActions';
+import history from '../../history';
 
 const RegisterSchema = Yup.object().shape({
   firstName: Yup.string().max(20, 'Too Long').required('Required'),
@@ -33,12 +34,8 @@ const FormikRegisterForm = withFormik({
   validateOnChange: false,
   validateOnBlur: false,
   handleSubmit(values, { props }: { [key: string]: any }) {
-    props.registerAccount(values, props.search);
+    props.registerAccount(values, history.location.search);
   },
 })(RegisterForm as React.FC);
 
-const mapStateToProps = (state: { [key: string]: any }) => ({
-  search: state.router.location.search,
-});
-
-export default connect(mapStateToProps, { registerAccount })(FormikRegisterForm);
+export default connect(null, { registerAccount })(FormikRegisterForm);

--- a/src/auth/containers/SignInForm.tsx
+++ b/src/auth/containers/SignInForm.tsx
@@ -4,6 +4,7 @@ import * as Yup from 'yup';
 
 import SignInForm from '../components/SignInForm';
 import { loginUser } from '../authActions';
+import history from '../../history';
 
 const LoginSchema = Yup.object().shape({
   email: Yup.string().email('Invalid Email').required('Required'),
@@ -21,13 +22,9 @@ const FormikSignInForm = withFormik({
   validateOnChange: false,
   validateOnBlur: false,
   handleSubmit(values, { resetForm, props }: { [key: string]: any }) {
-    props.loginUser(values, props.search);
+    props.loginUser(values, history.location.search);
     resetForm();
   },
 })(SignInForm as React.FC);
 
-const mapStateToProps = (state: { [key: string]: any }) => ({
-  search: state.router.location.search,
-});
-
-export default connect(mapStateToProps, { loginUser })(FormikSignInForm);
+export default connect(null, { loginUser })(FormikSignInForm);

--- a/src/auth/containers/requireAdminAuth.tsx
+++ b/src/auth/containers/requireAdminAuth.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { compose, Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { replace } from 'connected-react-router';
 
+import history from '../../history';
 import { verifyToken } from '../authActions';
 
 const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
@@ -39,7 +39,7 @@ const mapStateToProps = (state: { [key: string]: any }) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   redirectHome: () => {
-    dispatch(replace('/'));
+    history.replace('/');
   },
   verify: () => {
     return verifyToken(dispatch);

--- a/src/auth/containers/requireAdminAuth.tsx
+++ b/src/auth/containers/requireAdminAuth.tsx
@@ -6,13 +6,13 @@ import history from '../../history';
 import { verifyToken } from '../authActions';
 
 const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
-  const { authenticated, pathname, search, verify, redirectHome, isAdmin } = props;
+  const { authenticated, verify, redirectHome, isAdmin } = props;
 
   useEffect(() => {
     // check if authenticated, if not, then verify the token
     if (!authenticated) {
       // using then here because state doesn't update in right order
-      verify()(search, pathname)
+      verify()(history.location.search, history.location.pathname)
         .then((data: { [key: string]: any }) => {
           if (!data.admin) {
             // if not an admin, redirect
@@ -24,7 +24,7 @@ const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) =
       // if not an admin, redirect
       redirectHome();
     }
-  }, [authenticated, isAdmin, verify, redirectHome, search, pathname]);
+  }, [authenticated, isAdmin, verify, redirectHome]);
 
   // TODO: Make redirecting screen and return that if not authenticated.
   return <Component />;
@@ -32,8 +32,6 @@ const withAdminAuth = (Component: React.FC) => (props: { [key: string]: any }) =
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   authenticated: state.auth.authenticated,
-  pathname: state.router.location.pathname,
-  search: state.router.location.search,
   isAdmin: state.auth.admin,
 });
 

--- a/src/auth/containers/requireAuth.tsx
+++ b/src/auth/containers/requireAuth.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { compose, Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { replace } from 'connected-react-router';
 
+import history from '../../history';
 import { verifyToken } from '../authActions';
 
 const withAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
@@ -31,7 +31,7 @@ const mapStateToProps = (state: { [key: string]: any }) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   redirectLogin: () => {
-    dispatch(replace('/login'));
+    history.replace('/login');
   },
   verify: () => {
     return verifyToken(dispatch);

--- a/src/auth/containers/requireAuth.tsx
+++ b/src/auth/containers/requireAuth.tsx
@@ -6,14 +6,14 @@ import history from '../../history';
 import { verifyToken } from '../authActions';
 
 const withAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
-  const { authenticated, pathname, search, verify } = props;
+  const { authenticated, verify } = props;
 
   useEffect(() => {
     // check if authenticated, if not, then verify the token
     if (!authenticated) {
-      verify()(search, pathname);
+      verify()(history.location.search, history.location.pathname);
     }
-  }, [authenticated, verify, search, pathname]);
+  }, [authenticated, verify]);
 
   if (authenticated) {
     return <Component />;
@@ -25,8 +25,6 @@ const withAuth = (Component: React.FC) => (props: { [key: string]: any }) => {
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   authenticated: state.auth.authenticated,
-  pathname: state.router.location.pathname,
-  search: state.router.location.search,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/auth/containers/requireStoreAccess.tsx
+++ b/src/auth/containers/requireStoreAccess.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { compose, Dispatch } from 'redux';
+import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { replace } from 'connected-react-router';
+import history from '../../history';
 import { notify } from '../../utils';
 import PageLayout from '../../layout/containers/PageLayout';
 import { UserState } from '../../types';
@@ -39,10 +39,10 @@ const mapStateToProps = (state: { [key: string]: any }) => ({
   email: state.auth.profile.email,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
+const mapDispatchToProps = () => ({
   redirectHome: () => {
     notify('Store Requirement', 'You need a verified account with an @ucsd.edu address to use the store. Visit your profile to update your email.');
-    dispatch(replace('/'));
+    history.replace('/');
   },
 });
 

--- a/src/event/containers/CheckInHandler.tsx
+++ b/src/event/containers/CheckInHandler.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect } from 'react-router-dom';
+import { Redirect, useLocation } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { checkIn } from '../eventActions';
@@ -10,15 +10,14 @@ interface CheckInHandlerProps {
 }
 
 const CheckInHandler: React.FC<CheckInHandlerProps> = (props) => {
-  const { query, checkIn: reduxCheckIn } = props;
+  const { checkIn: reduxCheckIn } = props;
 
-  reduxCheckIn({ attendanceCode: decodeURIComponent(query.code || ''), asStaff: false });
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  reduxCheckIn({ attendanceCode: decodeURIComponent(params.get('code') || ''), asStaff: false });
 
   return <Redirect to="/" />;
 };
 
-const mapStateToProps = (state: { [key: string]: any }) => ({
-  query: state.router.location.query,
-});
-
-export default connect(mapStateToProps, { checkIn })(CheckInHandler);
+export default connect(null, { checkIn })(CheckInHandler);

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,8 @@
+import { createBrowserHistory } from 'history';
+import ReactGA from 'react-ga';
+
+const history = createBrowserHistory();
+
+history.listen((location) => ReactGA.pageview(location.pathname));
+
+export default history;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ConnectedRouter } from 'connected-react-router';
-import { Route, Switch } from 'react-router-dom';
+import { Router, Route, Switch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 
 import ReactGA from 'react-ga';
 import BreadPage from './layout/components/BreadPage';
 
-import configureStore, { history } from './redux_store';
+import history from './history';
+import configureStore from './redux_store';
 
 import './styles/reset.less';
 import AboutPage from './layout/containers/AboutPage';
@@ -58,7 +58,7 @@ const App = () => {
 
   return (
     <Provider store={store}>
-      <ConnectedRouter history={history}>
+      <Router history={history}>
         <Switch>
           <Route exact path="/about" component={requireAuth(AboutPage)} />
           <Route exact path="/admin" component={requireAdminAuth(AdminPage)} />
@@ -101,7 +101,7 @@ const App = () => {
           <Route exact path="/" component={requireAuth(HomePage)} />
           <Route path="/" component={requireAuth(ErrorPage)} />
         </Switch>
-      </ConnectedRouter>
+      </Router>
     </Provider>
   );
 };

--- a/src/redux_reducers.ts
+++ b/src/redux_reducers.ts
@@ -1,7 +1,4 @@
 import { combineReducers } from 'redux';
-import { connectRouter } from 'connected-react-router';
-import { History } from 'history';
-
 import AdminReducer from './admin/adminReducer';
 import AuthReducer from './auth/authReducer';
 import EventReducer from './event/eventReducer';
@@ -9,9 +6,8 @@ import LeaderboardReducer from './leaderboard/leaderboardReducer';
 import ProfileReducer from './profile/profileReducer';
 import StoreReducer from './store/storeReducer';
 
-export default (history: History) =>
+export default () =>
   combineReducers({
-    router: connectRouter(history),
     admin: AdminReducer,
     auth: AuthReducer,
     event: EventReducer,

--- a/src/redux_store.ts
+++ b/src/redux_store.ts
@@ -1,25 +1,13 @@
 import thunk from 'redux-thunk';
 import { applyMiddleware, compose, createStore } from 'redux';
-import { createBrowserHistory } from 'history';
-import { routerMiddleware } from 'connected-react-router';
-
-import ReactGA from 'react-ga';
 
 import createRootReducer from './redux_reducers';
 
-export const history = createBrowserHistory();
-history.listen((location) => ReactGA.pageview(location.pathname));
-
 export default function configureStore(preloadedState?: { [key: string]: any }) {
   const store = createStore(
-    createRootReducer(history), // root reducer with router state
+    createRootReducer(), // root reducer with router state
     preloadedState,
-    compose(
-      applyMiddleware(
-        routerMiddleware(history), // for dispatching history actions
-        thunk,
-      ),
-    ),
+    compose(applyMiddleware(thunk)),
   );
   return store;
 }

--- a/src/store/components/AdminCollectionPage/index.tsx
+++ b/src/store/components/AdminCollectionPage/index.tsx
@@ -3,7 +3,7 @@ import { Formik } from 'formik';
 import * as Yup from 'yup';
 
 import Config from '../../../config';
-import { history } from '../../../redux_store';
+import history from '../../../history';
 import { PublicMerchCollection } from '../../../types';
 import { fetchService, notify } from '../../../utils';
 

--- a/src/store/components/AdminItemPage/index.tsx
+++ b/src/store/components/AdminItemPage/index.tsx
@@ -3,7 +3,7 @@ import { Formik } from 'formik';
 import * as Yup from 'yup';
 
 import Config from '../../../config';
-import { history } from '../../../redux_store';
+import history from '../../../history';
 import { PublicMerchCollection, PublicMerchItem } from '../../../types';
 import { fetchService, notify } from '../../../utils';
 

--- a/src/store/components/AdminPickupPage/index.tsx
+++ b/src/store/components/AdminPickupPage/index.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import * as Yup from 'yup';
 
 import Config from '../../../config';
-import { history } from '../../../redux_store';
+import history from '../../../history';
 import { PublicOrderPickupEvent } from '../../../types';
 import { fetchService, notify } from '../../../utils';
 

--- a/src/store/components/CheckoutPage/index.tsx
+++ b/src/store/components/CheckoutPage/index.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { CartItem, PublicOrderPickupEvent } from '../../../types';
 import CartDisplay from '../CartDisplay';
 import Config from '../../../config';
-import { history } from '../../../redux_store';
+import history from '../../../history';
 import StoreButton from '../StoreButton';
 import StoreDropdown from '../StoreDropdown';
 import StoreHeader from '../StoreHeader';

--- a/src/store/containers/CartPage.tsx
+++ b/src/store/containers/CartPage.tsx
@@ -5,7 +5,7 @@ import PageLayout from '../../layout/containers/PageLayout';
 import CartPage from '../components/CartPage';
 
 import Config from '../../config';
-import { history } from '../../redux_store';
+import history from '../../history';
 import { CartItem } from '../../types';
 import { fetchService, notify } from '../../utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,13 +3542,6 @@ connect-history-api-fallback@^1.3.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
 
-connected-react-router@^6.5.2:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-6.8.0.tgz#ddc687b31d498322445d235d660798489fa56cae"
-  integrity sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==
-  dependencies:
-    prop-types "^15.7.2"
-
 console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"


### PR DESCRIPTION
History management has now been pulled out of the Redux state. It looks like history was added in to allow for page navigation via Redux dispatches, but that's never something that was implemented and just added to boilerplate code. There's now a `history.ts` file that can be imported wherever a `history.push` or `history.replace` is needed outside of a component. For usages inside of a component, `useHistory` or `useLocation` can continue to be used. This removes the need for the `connected-react-router` package, as our router is now state independent.