### PR TITLE
fix external url redirect and breakpoint

### DIFF
--- a/src/event/components/EventCard/index.tsx
+++ b/src/event/components/EventCard/index.tsx
@@ -62,7 +62,7 @@ const EventCard: React.FC<EventCardProps> = (props) => {
           <>
             <br />
             <br />
-            <a href={eventLink}>
+            <a href={getAbsoluteURL(eventLink)}>
               <p className="event-link">{eventLink}</p>
             </a>
           </>

--- a/src/layout/components/PageLayout/index.tsx
+++ b/src/layout/components/PageLayout/index.tsx
@@ -43,7 +43,7 @@ const PageLayout: React.FC<PageLayoutProps> = (props) => {
 };
 
 const mapSizesToProps = ({ width }: { width: number }) => ({
-  isMobile: width < 768,
+  isMobile: width <= 768,
 });
 
 const mapDispatchToProps = (dispatch: ThunkActionCreator) => ({


### PR DESCRIPTION
This PR fixes two separate bugs.

1: External URLs are not always prefixed with https:// so they sometimes will not properly redirect. Fixed with existing utility function to deal with this.
![Screen Shot 2022-04-27 at 8 16 18 PM](https://user-images.githubusercontent.com/33165426/165669469-53c47d93-2e1d-4e2a-ad95-9985c7fc636a.jpg)

2: The breakpoint at 768px was inconsistent on the navbar and resulted in two shifts at 767px and 768px rather than a single shift.