### PR TITLE
Fix Password Reset API Call

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -38,7 +38,7 @@ export const loginUser = async (email: string, password: string) => {
   return data;
 };
 
-export const updatePassword = (user) => async () => {
+export const updatePassword = async (user) => {
   try {
     const url = `${Config.API_URL}${Config.routes.auth.resetPassword}/${user.code}`;
     await fetchService(url, 'POST', 'json', {


### PR DESCRIPTION
There was an issue where there was a stray double function, so calling the helper function to reset a user's password was only generating a function and wasn't actually executing the call.

Resolves #566 