### PR TITLE
Update Store Admin Pickup Dropdown Conditions

### DIFF
--- a/src/store/containers/AdminFulfillPage.tsx
+++ b/src/store/containers/AdminFulfillPage.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch } from '../../redux/store';
 import { PublicOrderPickupEvent } from '../../types';
 import { notify } from '../../utils';
 import AdminFulfillPage from '../components/AdminFulfillPage';
-import { fetchFuturePickupEvents, fetchPickupEvent } from '../storeSlice';
+import { fetchPastPickupEvents, fetchFuturePickupEvents, fetchPickupEvent } from '../storeSlice';
 
 interface AdminFulfillPageContainerProps {}
 
@@ -14,7 +14,8 @@ const AdminFulfillPageContainer: React.FC<AdminFulfillPageContainerProps> = () =
   const { uuid } = params;
 
   const [pickupEvent, setPickupEvent] = useState<PublicOrderPickupEvent>();
-  const [pickupEvents, setPickupEvents] = useState<Array<PublicOrderPickupEvent>>();
+  const [pastPickupEvents, setPastPickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
+  const [futurePickupEvents, setFuturePickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -24,16 +25,24 @@ const AdminFulfillPageContainer: React.FC<AdminFulfillPageContainerProps> = () =
         .then((value) => setPickupEvent(value))
         .catch((reason) => notify('API Error', reason.message || reason));
     } else {
+      dispatch(fetchPastPickupEvents())
+        .unwrap()
+        .then((value) => setPastPickupEvents(value))
+        .catch((reason) => notify('API Error', reason.message || reason));
       dispatch(fetchFuturePickupEvents())
         .unwrap()
-        .then((value) => setPickupEvents(value))
+        .then((value) => setFuturePickupEvents(value))
         .catch((reason) => notify('API Error', reason.message || reason));
     }
   }, [uuid, dispatch]);
 
+  const activePickupEvents = pastPickupEvents.concat(futurePickupEvents).filter((pEvent) => {
+    return pEvent.status === 'ACTIVE';
+  });
+
   return (
     <PageLayout>
-      <AdminFulfillPage pickupEvent={pickupEvent} pickupEvents={pickupEvents} />
+      <AdminFulfillPage pickupEvent={pickupEvent} pickupEvents={activePickupEvents} />
     </PageLayout>
   );
 };

--- a/src/store/containers/AdminPickupPage.tsx
+++ b/src/store/containers/AdminPickupPage.tsx
@@ -5,14 +5,15 @@ import { useAppDispatch } from '../../redux/store';
 import { PublicOrderPickupEvent } from '../../types';
 import { notify } from '../../utils';
 import AdminPickupPage from '../components/AdminPickupPage';
-import { cancelPickupEvent, deletePickupEvent, fetchFuturePickupEvents, fetchPickupEvent } from '../storeSlice';
+import { cancelPickupEvent, deletePickupEvent, fetchPastPickupEvents, fetchFuturePickupEvents, fetchPickupEvent } from '../storeSlice';
 
 const AdminPickupPageContainer: React.FC = () => {
   const params: { [key: string]: any } = useParams();
   const { uuid } = params;
 
   const [pickupEvent, setPickupEvent] = useState<PublicOrderPickupEvent>();
-  const [pickupEvents, setPickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
+  const [pastPickupEvents, setPastPickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
+  const [futurePickupEvents, setFuturePickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -22,18 +23,26 @@ const AdminPickupPageContainer: React.FC = () => {
         .then((value) => setPickupEvent(value))
         .catch((reason) => notify('API Error', reason.message || reason));
     } else {
+      dispatch(fetchPastPickupEvents())
+        .unwrap()
+        .then((value) => setPastPickupEvents(value))
+        .catch((reason) => notify('API Error', reason.message || reason));
       dispatch(fetchFuturePickupEvents())
         .unwrap()
-        .then((value) => setPickupEvents(value))
+        .then((value) => setFuturePickupEvents(value))
         .catch((reason) => notify('API Error', reason.message || reason));
     }
   }, [dispatch, uuid]);
+
+  const activePickupEvents = pastPickupEvents.concat(futurePickupEvents).filter((pEvent) => {
+    return pEvent.status === 'ACTIVE';
+  });
 
   return (
     <PageLayout>
       <AdminPickupPage
         pickupEvent={pickupEvent}
-        pickupEvents={pickupEvents}
+        pickupEvents={activePickupEvents}
         deletePickupEvent={deletePickupEvent}
         cancelPickupEvent={cancelPickupEvent}
       />

--- a/src/store/containers/AdminPreparePage.tsx
+++ b/src/store/containers/AdminPreparePage.tsx
@@ -5,14 +5,15 @@ import { useAppDispatch } from '../../redux/store';
 import { PublicOrderPickupEvent } from '../../types';
 import { notify } from '../../utils';
 import AdminPreparePage from '../components/AdminPreparePage';
-import { fetchFuturePickupEvents, fetchPickupEvent } from '../storeSlice';
+import { fetchPastPickupEvents, fetchFuturePickupEvents, fetchPickupEvent } from '../storeSlice';
 
 const AdminPreparePageContainer: React.FC = () => {
   const params: { [key: string]: any } = useParams();
   const { uuid } = params;
 
   const [pickupEvent, setPickupEvent] = useState<PublicOrderPickupEvent>();
-  const [pickupEvents, setPickupEvents] = useState<Array<PublicOrderPickupEvent>>();
+  const [pastPickupEvents, setPastPickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
+  const [futurePickupEvents, setFuturePickupEvents] = useState<Array<PublicOrderPickupEvent>>([]);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -26,10 +27,18 @@ const AdminPreparePageContainer: React.FC = () => {
           notify('API Error', reason.message || reason);
         });
     } else {
+      dispatch(fetchPastPickupEvents())
+        .unwrap()
+        .then((value) => {
+          setPastPickupEvents(value);
+        })
+        .catch((reason) => {
+          notify('API Error', reason.message || reason);
+        });
       dispatch(fetchFuturePickupEvents())
         .unwrap()
         .then((value) => {
-          setPickupEvents(value);
+          setFuturePickupEvents(value);
         })
         .catch((reason) => {
           notify('API Error', reason.message || reason);
@@ -37,9 +46,13 @@ const AdminPreparePageContainer: React.FC = () => {
     }
   }, [dispatch, uuid]);
 
+  const activePickupEvents = pastPickupEvents.concat(futurePickupEvents).filter((pEvent) => {
+    return pEvent.status === 'ACTIVE';
+  });
+
   return (
     <PageLayout>
-      <AdminPreparePage pickupEvent={pickupEvent} pickupEvents={pickupEvents} />
+      <AdminPreparePage pickupEvent={pickupEvent} pickupEvents={activePickupEvents} />
     </PageLayout>
   );
 };

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -301,7 +301,7 @@ export const fetchPickupEvent = (uuid: string) =>
   });
 
 export const fetchPastPickupEvents = () =>
-  new Promise(async (resolve, reject) => {
+  new Promise<PublicOrderPickupEvent[]>(async (resolve, reject) => {
     try {
       const url = `${Config.API_URL}${Config.routes.store.pickup.past}`;
       const data = await fetchService(url, 'GET', 'json', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,12 @@ export interface PublicOrderForFulfillment extends PublicOrder {
   items: PublicOrderItemForFulfillment[];
 }
 
+export enum OrderPickupEventStatus {
+  ACTIVE = 'ACTIVE',
+  CANCELLED = 'CANCELLED',
+  COMPLETED = 'COMPLETED',
+}
+
 export interface PublicOrderPickupEvent {
   uuid: Uuid;
   title: string;
@@ -182,4 +188,5 @@ export interface PublicOrderPickupEvent {
   description: string;
   orders?: PublicOrderWithItems[];
   orderLimit?: number;
+  status: OrderPickupEventStatus;
 }


### PR DESCRIPTION
Previously, store admins were only shown currently ongoing and future pickup events in the dropdown for store fulfillment. However, this meant that a pickup event disappeared as soon as it was over, so if it hadn't already been marked as complete, then someone from dev needed to find its uuid and manually access the page. The dropdown condition is now changed to display both past and future pickup events that have a status of active, which will allow admins to both fulfill orders and mark pickup events as complete even after their original time window has passed.