### PR TITLE
Fix error handling

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,24 @@
+// seems reasonable to put all errors in this file
+/* eslint-disable max-classes-per-file */
+
+export class UserError extends Error {
+  public message: string;
+
+  constructor(message: string) {
+    super();
+
+    Object.setPrototypeOf(this, UserError.prototype);
+    this.message = message;
+  }
+}
+
+export class AuthError extends Error {
+  public message: string;
+
+  constructor(message: string) {
+    super();
+
+    Object.setPrototypeOf(this, AuthError.prototype);
+    this.message = message;
+  }
+}

--- a/src/event/eventSlice.ts
+++ b/src/event/eventSlice.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
 import { fetchUser, logoutUser, withLogout } from '../auth/authSlice';
+import { AuthError } from '../errors';
 import type { RootState } from '../redux/store';
 import * as utils from './utils';
 
@@ -39,7 +40,7 @@ export const checkIn = createAsyncThunk<any, any>('event/checkIn', async (info, 
     dispatch(fetchFutureEvents());
     return data;
   } catch (error) {
-    dispatch(logoutUser());
+    if (error instanceof AuthError) dispatch(logoutUser());
     throw error;
   }
 });

--- a/src/event/utils.ts
+++ b/src/event/utils.ts
@@ -57,7 +57,7 @@ export const checkIn = async (info) => {
     return data.event;
   } catch (error) {
     notify('Unable to checkin!', getErrorMessage(error));
-    throw new Error(getErrorMessage(error));
+    throw error;
   }
 };
 

--- a/src/leaderboard/leaderboardSlice.ts
+++ b/src/leaderboard/leaderboardSlice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { logoutUser } from '../auth/authSlice';
+import { AuthError } from '../errors';
 import type { RootState } from '../redux/store';
 import { PublicProfile } from '../types';
 import { getDefaultProfile } from '../utils';
@@ -23,7 +24,7 @@ export const fetchLeaderboard = createAsyncThunk<
     const data = await utils.fetchLeaderboard(args.offset, args.limit, args.from, args.to);
     return data;
   } catch (error) {
-    dispatch(logoutUser());
+    if (error instanceof AuthError) dispatch(logoutUser());
     throw error;
   }
 });

--- a/src/leaderboard/utils.ts
+++ b/src/leaderboard/utils.ts
@@ -9,7 +9,5 @@ export const fetchLeaderboard = async (offset: number = 0, limit: number, from?:
     requiresAuthorization: true,
   });
 
-  if (!data) throw new Error('Empty response from server');
-  if (data.error) throw new Error(data.error.message);
   return data.leaderboard as PublicProfile[];
 };

--- a/src/profile/profileSlice.ts
+++ b/src/profile/profileSlice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { logoutUser, withLogout } from '../auth/authSlice';
+import { AuthError } from '../errors';
 import * as utils from './utils';
 
 const initialState = {
@@ -11,7 +12,7 @@ export const updateProfile = createAsyncThunk('utils/updateProfile', async (valu
   try {
     await utils.updateProfile(values);
   } catch (error) {
-    dispatch(logoutUser());
+    if (error instanceof AuthError) dispatch(logoutUser());
   }
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export type MimeType = 'json' | 'image';
 export type FetchServiceOptions = {
   requiresAuthorization: boolean;
   payload?: any;
-  onFailCallback?: () => void;
 };
 
 export enum UserAccessType {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -3,6 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import Storage from './storage';
 import DiamondDisplay from './store/components/DiamondDisplay';
 import { FetchServiceOptions, HttpRequestMethod, MimeType, OrderStatus, PublicMerchItemOption } from './types';
+import { AuthError, UserError } from './errors';
 
 export const notify = (title: string, description: string) => {
   showNotification({
@@ -159,7 +160,7 @@ const getServiceErrorMessage = (error) => {
  * Fetches data from server with simple error handling
  */
 export const fetchService = async (url: string, requestMethod: HttpRequestMethod, mimeType: MimeType, options: FetchServiceOptions) => {
-  const { payload, requiresAuthorization, onFailCallback } = options;
+  const { payload, requiresAuthorization } = options;
 
   let Accept;
   let ContentType;
@@ -187,9 +188,9 @@ export const fetchService = async (url: string, requestMethod: HttpRequestMethod
   });
 
   const { status } = response;
-  if (status === 401 || status === 403) onFailCallback?.();
+  if (status === 401 || status === 403) throw new AuthError('');
   const data = await response.json();
-  if (!data) throw new Error('Empty response from server');
+  if (!data) throw new AuthError('Empty response from server');
   if (data.error) {
     let { message } = data.error;
     if (status === 400 && data.error.errors) {
@@ -200,7 +201,7 @@ export const fetchService = async (url: string, requestMethod: HttpRequestMethod
       }
       message = messages;
     }
-    throw new Error(message);
+    throw new UserError(message);
   }
 
   return data;


### PR DESCRIPTION
This PR adds `UserError` and `AuthError` types to differentiate between server errors. In the redux cleaning, I was dispatching logout on all server errors but now I only dispatch logout on `AuthError`. 

In the future, I think there should be a more unified way of handling `UserError` as generally, we just notify with an error message which can be abstracted. I've already created this kind of abstraction in `src/auth/authSlice.ts` in the `withLogout` HOF which takes an async function `f` and returns an async thunk that dispatches a logout when `f` throws an `AuthError`. I think a similar HOF could be created for `UserError` which sends a notify if a `UserError` is thrown. If such a `withNotify` HOF is created, then `withLogout` would probably have to be modified to allow for error chaining before creating the async thunk.