### PR TITLE
Redo dashboard card responsiveness

### DIFF
--- a/src/event/components/EventCheckIn/style.less
+++ b/src/event/components/EventCheckIn/style.less
@@ -9,6 +9,7 @@
   justify-content: center;
   margin: 0;
   max-width: @db-card-width;
+  min-width: @db-card-width-min;
 
   .staff-checkin-div {
     margin-top: 12px;

--- a/src/layout/components/HomePage/style.less
+++ b/src/layout/components/HomePage/style.less
@@ -25,16 +25,17 @@
   .dashboard {
     display: flex;
     flex-wrap: wrap;
+    gap: 5%;
     padding: 40px 0;
 
     > div {
+      flex-grow: 1;
       margin-bottom: 50px;
       width: 45%;
     }
 
     .profile-card {
       background-color: inherit;
-      margin-right: 5%;
     }
   }
 

--- a/src/profile/components/ProfileCard/style.less
+++ b/src/profile/components/ProfileCard/style.less
@@ -12,13 +12,20 @@
   justify-content: center;
   margin: 0;
   max-width: @db-card-width;
+  min-width: @db-card-width-min;
   overflow: hidden;
   white-space: nowrap;
+
+  .ant-card-body {
+    max-width: 100%;
+  }
 
   h2 {
     font-size: @card-heading-1;
     font-weight: 700;
     margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   h3 {
@@ -41,6 +48,7 @@
 
   .info {
     display: inline-block;
+    max-width: calc(100% - 145px); // 145px is width of avatar and its margin
     -ms-overflow-style: none;
     overflow-x: scroll;
     scrollbar-width: none;

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -98,6 +98,7 @@
 // Component Sizes
 @db-card-width: 400px;
 @db-card-height: 200px;
+@db-card-width-min: 320px;
 
 @event-width: 288px;
 @event-height: 280px;


### PR DESCRIPTION
Redo #584 after the rollback. Cards now have a minimum width and flex into 2 lines instead of overflowing.
![image](https://user-images.githubusercontent.com/30709485/201250788-cda294e5-0170-4f09-a004-fc69b35cbb68.png)

