### PR TITLE
Fix Add to Cart Broken Functionality

### DIFF
--- a/src/store/components/ItemPage/index.tsx
+++ b/src/store/components/ItemPage/index.tsx
@@ -4,7 +4,7 @@ import { Dispatch } from 'redux';
 import { replace } from 'connected-react-router';
 import { Modal } from 'antd';
 
-import { PublicMerchItemWithPurchaseLimits, PublicMerchItemOption, UserAccessType } from '../../../types';
+import { PublicMerchItemWithPurchaseLimits, PublicMerchItemOption, UserAccessType, CartItem } from '../../../types';
 import { processItem, processItemPrice } from '../../../utils';
 import { addToCart } from '../../storeActions';
 
@@ -158,12 +158,12 @@ const ItemPage: React.FC<ItemPageProps> = (props) => {
   );
 };
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  redirect: (rejectRoute: string) => {
+const mapDispatchToProps = {
+  addToCart,
+  redirect: (rejectRoute: string) => (dispatch: any) => {
     dispatch(replace(rejectRoute));
   },
-  addToCart,
-});
+};
 
 const mapStateToProps = (state: { [key: string]: any }) => ({
   isStoreAdmin: [UserAccessType.ADMIN, UserAccessType.MERCH_STORE_MANAGER].includes(state.auth.profile.accessType),

--- a/src/store/components/ItemPage/index.tsx
+++ b/src/store/components/ItemPage/index.tsx
@@ -4,7 +4,7 @@ import { Dispatch } from 'redux';
 import { replace } from 'connected-react-router';
 import { Modal } from 'antd';
 
-import { PublicMerchItemWithPurchaseLimits, PublicMerchItemOption, UserAccessType, CartItem } from '../../../types';
+import { PublicMerchItemWithPurchaseLimits, PublicMerchItemOption, UserAccessType } from '../../../types';
 import { processItem, processItemPrice } from '../../../utils';
 import { addToCart } from '../../storeActions';
 
@@ -160,7 +160,7 @@ const ItemPage: React.FC<ItemPageProps> = (props) => {
 
 const mapDispatchToProps = {
   addToCart,
-  redirect: (rejectRoute: string) => (dispatch: any) => {
+  redirect: (rejectRoute: string) => (dispatch: Dispatch) => {
     dispatch(replace(rejectRoute));
   },
 };


### PR DESCRIPTION
Fixed bug preventing add to cart functionality from working due to issue in incorrect mapDispatchToprops function because addToCart was undefined.

Expected behavior to test for:
- Add to Cart works correctly now
- Hidden item url redirect for non-store admins (Previous PR change)